### PR TITLE
Reverted logger breaking change

### DIFF
--- a/SpaceWarp/API/Logging/BaseModLogger.cs
+++ b/SpaceWarp/API/Logging/BaseModLogger.cs
@@ -5,13 +5,13 @@
     /// </summary>
     public abstract class BaseModLogger
     {
-        protected abstract void Log(LogLevel level, string message, params object[] args);
+        protected abstract void Log(LogLevel level, string message);
 
-        public void Trace(string message, params object[] args) => Log(LogLevel.Trace, message, args);
-        public void Debug(string message, params object[] args) => Log(LogLevel.Debug, message, args);
-        public void Info(string message, params object[] args) => Log(LogLevel.Info, message, args);
-        public void Warn(string message, params object[] args) => Log(LogLevel.Warn, message, args);
-        public void Error(string message, params object[] args) => Log(LogLevel.Error, message, args);
-        public void Critical(string message, params object[] args) => Log(LogLevel.Critical, message, args);
+        public void Trace(string message) => Log(LogLevel.Trace, message);
+        public void Debug(string message) => Log(LogLevel.Debug, message);
+        public void Info(string message) => Log(LogLevel.Info, message);
+        public void Warn(string message) => Log(LogLevel.Warn, message);
+        public void Error(string message) => Log(LogLevel.Error, message);
+        public void Critical(string message) => Log(LogLevel.Critical, message);
     }
 }

--- a/SpaceWarp/API/Logging/ModLogger.cs
+++ b/SpaceWarp/API/Logging/ModLogger.cs
@@ -19,24 +19,23 @@ namespace SpaceWarp.API.Logging
             _moduleName = moduleName;
         }
         
-        private string BuildLogMessage(LogLevel level, string message, object[] args)
+        private string BuildLogMessage(LogLevel level, string message)
         {
             StringBuilder sb = new StringBuilder();
-            string formattedMessage = string.Format(message, args);
 
             sb.Append($"[{DateTime.Now:HH:mm:ss.fff}] ");
             sb.Append($"[{_moduleName}] ");
             sb.Append($"[{level}] ");
-            sb.Append(formattedMessage);
+            sb.Append(message);
 
             return sb.ToString();
         }
 
-        protected override void Log(LogLevel level, string message, params object[] args)
+        protected override void Log(LogLevel level, string message)
         {
             if ((int)level >= SpaceWarpGlobalConfiguration.Instance.LogLevel)
             {
-                string logMessage = BuildLogMessage(level, message, args);
+                string logMessage = BuildLogMessage(level, message);
                 UnityEngine.Debug.Log(logMessage);
             }
         }


### PR DESCRIPTION
Is there any good reason for this change in the logger?

It doesn't seem to bring anything new/needed, as string interpolation offers the same feature but without breaking any mods that previously used logging.

From [Microsoft](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/tokens/interpolated): String interpolation provides a more readable, convenient syntax to format strings. It's easier to read than string composite formatting.

Instead of `Logger.Info("Logging x: {0}", x);` we can just do `Logger.Info($"Logging x: {x}");`