### PR TITLE
Protected inheritance

### DIFF
--- a/SpaceWarp/Compilation/ModCompiler.cs
+++ b/SpaceWarp/Compilation/ModCompiler.cs
@@ -7,14 +7,16 @@ using Microsoft.CodeAnalysis.CSharp;
 using SpaceWarp.API;
 using SpaceWarp.API.Logging;
 using UniLinq;
+using Enumerable = System.Linq.Enumerable;
 
 namespace SpaceWarp.Compilation;
 
 public static class ModCompiler
 {
-    public static string CACHE_LOCATION = SpaceWarpManager.SPACE_WARP_PATH + "mod_cache/";
+    public static readonly string CACHE_LOCATION = SpaceWarpManager.SPACE_WARP_PATH + "mod_cache/";
 
     private static BaseModLogger _logger = new ModLogger("Roslyn Compilation");
+    
     public static Assembly CompileMod(string modID, string modSrcPath)
     {
         try
@@ -45,15 +47,16 @@ public static class ModCompiler
         
     private static string[] AllSourceFiles(string modSrcPath)
     {
-        DirectoryInfo d = new DirectoryInfo(modSrcPath);
-        string[] sourceFiles = d.EnumerateFiles("*.cs", SearchOption.AllDirectories).Select(a => a.FullName)
+        DirectoryInfo directoryInfo = new DirectoryInfo(modSrcPath);
+        string[] sourceFiles = directoryInfo.EnumerateFiles("*.cs", SearchOption.AllDirectories)
+            .Select(fileInfo => fileInfo.FullName)
             .ToArray();
         return sourceFiles;
     }
 
     private static bool CreateNewCompilation(string modID, string modSrcPath)
     {
-        var allSourceFiles = AllSourceFiles(modSrcPath);
+        string[] allSourceFiles = AllSourceFiles(modSrcPath);
         DateTime latestWriteTime = DateTime.FromBinary(0);
         foreach (var sourceFile in allSourceFiles)
         {
@@ -89,21 +92,21 @@ public static class ModCompiler
 
     private static Assembly CompileNewAssemblyAndCache(string modID, string modSrcPath)
     {
-        var allSourceFiles = AllSourceFiles(modSrcPath);
-        List<SyntaxTree> trees = new List<SyntaxTree>();
-        foreach (string file in allSourceFiles)
-        {
-            string code = File.ReadAllText(file);
-            SyntaxTree tree = CSharpSyntaxTree.ParseText(code);
-            trees.Add(tree);
-        }
+        string[] allSourceFiles = AllSourceFiles(modSrcPath);
+        List<SyntaxTree> trees = Enumerable.ToList(
+            Enumerable.Select(
+                Enumerable.Select(allSourceFiles, File.ReadAllText),
+                code => CSharpSyntaxTree.ParseText(code)
+            )
+        );
 
-        List<MetadataReference> references = new List<MetadataReference>();
-        foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies())
-        {
-            if (asm.IsDynamic) continue;
-            references.Add(MetadataReference.CreateFromFile(asm.Location));
-        }
+        List<MetadataReference> references = Enumerable.ToList(
+            Enumerable.Cast<MetadataReference>(
+                from asm in AppDomain.CurrentDomain.GetAssemblies() 
+                where !asm.IsDynamic 
+                select MetadataReference.CreateFromFile(asm.Location)
+            )
+        );
 
         var compilation = CSharpCompilation.Create(modID + ".dll", trees, references,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true));

--- a/SpaceWarp/Patching/LoadingActions/AfterModsLoadedAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/AfterModsLoadedAction.cs
@@ -12,7 +12,7 @@ public class AfterModsLoadedAction : FlowAction
         //
     }
 
-    public override void DoAction(Action resolve, Action<string> reject)
+    protected override void DoAction(Action resolve, Action<string> reject)
     {
         ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
 

--- a/SpaceWarp/Patching/LoadingActions/LoadAssetAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/LoadAssetAction.cs
@@ -16,7 +16,7 @@ public class LoadAssetAction : FlowAction
         _info = info;
     }
 
-    public override void DoAction(Action resolve, Action<string> reject)
+    protected override void DoAction(Action resolve, Action<string> reject)
     {
         ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
 

--- a/SpaceWarp/Patching/LoadingActions/LoadAssetsAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/LoadAssetsAction.cs
@@ -12,7 +12,7 @@ public class LoadAssetsAction : FlowAction
 		//
 	}
 
-	public override void DoAction(Action resolve, Action<string> reject)
+	protected override void DoAction(Action resolve, Action<string> reject)
 	{
 		ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
 

--- a/SpaceWarp/Patching/LoadingActions/LoadModAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/LoadModAction.cs
@@ -17,7 +17,7 @@ public class LoadModAction : FlowAction
         _info = info;
     }
 
-    public override void DoAction(Action resolve, Action<string> reject)
+    protected override void DoAction(Action resolve, Action<string> reject)
     {
         ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
 

--- a/SpaceWarp/Patching/LoadingActions/LoadModsAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/LoadModsAction.cs
@@ -12,7 +12,7 @@ public class LoadModsAction : FlowAction
         //
     }
 
-    public override void DoAction(Action resolve, Action<string> reject)
+    protected override void DoAction(Action resolve, Action<string> reject)
     {
         ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
 

--- a/SpaceWarp/Patching/LoadingActions/ReadingModsAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/ReadingModsAction.cs
@@ -12,7 +12,7 @@ public class ReadingModsAction : FlowAction
         //
     }
 
-    public override void DoAction(Action resolve, Action<string> reject)
+    protected override void DoAction(Action resolve, Action<string> reject)
     {
         ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
 

--- a/SpaceWarp/Patching/LoadingActions/SpaceWarpAssetInitializationAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/SpaceWarpAssetInitializationAction.cs
@@ -11,7 +11,7 @@ public class SpaceWarpAssetInitializationAction : FlowAction
     {
     }
 
-    public override void DoAction(Action resolve, Action<string> reject)
+    protected override void DoAction(Action resolve, Action<string> reject)
     {
         ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
 

--- a/SpaceWarp/Patching/LoadingScreenPatcher.cs
+++ b/SpaceWarp/Patching/LoadingScreenPatcher.cs
@@ -1,5 +1,6 @@
 ﻿using KSP.Game;
 using SpaceWarp.API;
+using SpaceWarp.API.Logging;
 using SpaceWarp.API.Managers;
 using SpaceWarp.Patching.LoadingActions;
 
@@ -12,8 +13,7 @@ namespace SpaceWarp.Patching;
 public class LoadingScreenPatcher
 {
     public static void AddModLoadingScreens()
-    {	
-
+    {
         GameManager gameManager = GameManager.Instance;
         gameManager.LoadingFlow.AddAction(new ReadingModsAction("Resolving Space Warp Mod Load Order"));
         gameManager.LoadingFlow.AddAction(new SpaceWarpAssetInitializationAction("Initializing Space Warp Provided Assets"));
@@ -21,9 +21,15 @@ public class LoadingScreenPatcher
 
     public static void AddAllModLoadingSteps()
     {
-            
         GameManager gameManager = GameManager.Instance;
-        if (!ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager)) return; //TODO: Log a message here
+        ModLogger logger = new ModLogger(gameManager.name);
+
+        if (!ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager))
+        {
+            logger.Error("Space Warp Manager not found. Cannot add mod loading steps.");
+            return;
+        }
+        
         foreach (var mod in spaceWarpManager._modLoadOrder)
         {
             gameManager.LoadingFlow.AddAction(new LoadAssetAction($"Loading assets for {mod.Item1}",mod.Item1, mod.Item2));
@@ -31,6 +37,5 @@ public class LoadingScreenPatcher
         }
             
         gameManager.LoadingFlow.AddAction(new AfterModsLoadedAction("Space Warp Mod Post-Initialization"));
-            
     }
 }


### PR DESCRIPTION
Description:
This PR changes the access modifier of the `DoAction` method in the `AfterModsLoadedAction` class from `public` to `protected`. The change was made to match the access modifier of the overridden method in the base class.

In the previous implementation, the `DoAction` method was declared as `public`, which could potentially expose the method to unintended use outside of the class hierarchy. By changing the access modifier to `protected`, we restrict access to the method to only the current class and its derived classes. This provides better encapsulation and reduces the risk of unintended use or modification of the method.

Overall, this change improves the code quality and maintains consistency with the base class.

I also fixed the TODO: add logging here.. by adding logging there 🎉 