### PR TITLE
Misc UI cleanup

### DIFF
--- a/SpaceWarp/API/Toolbar/ToolbarBackend.cs
+++ b/SpaceWarp/API/Toolbar/ToolbarBackend.cs
@@ -82,7 +82,7 @@ public static class ToolbarBackend
 
 class ToolbarBackendObject : KerbalBehavior
 {
-    public void Start()
+    public new void Start()
     {
             
         StartCoroutine(awaiter());

--- a/SpaceWarp/API/Toolbar/ToolbarMenu.cs
+++ b/SpaceWarp/API/Toolbar/ToolbarMenu.cs
@@ -48,7 +48,7 @@ public abstract class ToolbarMenu : KerbalBehavior
     public string Title;
     private Rect _windowRect;
 
-    public void Awake()
+    public new void Awake()
     {
         _windowRect = new Rect(X, Y, 0, 0);
     }

--- a/SpaceWarp/SpaceWarp.csproj
+++ b/SpaceWarp/SpaceWarp.csproj
@@ -34,7 +34,7 @@
       <PackageReference Include="HarmonyX" Version="2.10.1" />
       <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" PrivateAssets="all" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
       <PackageReference Include="UnityEngine.Modules" Version="2020.3.33" />
       <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.0" PrivateAssets="all" />
     </ItemGroup>

--- a/SpaceWarp/SpaceWarp.csproj
+++ b/SpaceWarp/SpaceWarp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Version>0.3.0</Version>
-        <LangVersion>11</LangVersion>
+        <LangVersion>latest</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
         <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
@@ -34,7 +34,7 @@
       <PackageReference Include="HarmonyX" Version="2.10.1" />
       <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" PrivateAssets="all" />
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
       <PackageReference Include="UnityEngine.Modules" Version="2020.3.33" />
       <PackageReference Include="BepInEx.AssemblyPublicizer.MSBuild" Version="0.4.0" PrivateAssets="all" />
     </ItemGroup>

--- a/SpaceWarp/UI/ModListUI.cs
+++ b/SpaceWarp/UI/ModListUI.cs
@@ -45,7 +45,7 @@ public class ModListUI : KerbalMonoBehaviour
         _windowWidth = (int)(Screen.width * 0.85f);
         _windowHeight = (int)(Screen.height * 0.85f);
 
-        _windowRect = new Rect((Screen.width * 0.15f), (Screen.height * 0.15f), 0, 0);
+        _windowRect = new Rect(Screen.width * 0.15f, Screen.height * 0.15f, 0, 0);
         ResourceManager.TryGetAsset($"space_warp/swconsoleui/swconsoleUI/spacewarpConsole.guiskin", out _spaceWarpUISkin);
     }
 
@@ -125,9 +125,9 @@ public class ModListUI : KerbalMonoBehaviour
                 }
             }
         }
+        
         GUILayout.EndHorizontal();
 
-            
         int numChanges = 0;
         for (int i = 0; i < _toggles.Count; i++)
         {
@@ -146,7 +146,7 @@ public class ModListUI : KerbalMonoBehaviour
         {
             foreach ((string modID, ModInfo modInfo) in manager.LoadedMods)
             {
-                int toggleIndex = _toggles.FindIndex((t) => t.Item1 == modID);
+                int toggleIndex = _toggles.FindIndex(t => t.Item1 == modID);
                 if (toggleIndex == -1) // Toggle not found, add a new one
                 {
                     _toggles.Add((modID, true));

--- a/SpaceWarp/UI/SpaceWarpConsole.cs
+++ b/SpaceWarp/UI/SpaceWarpConsole.cs
@@ -20,9 +20,9 @@ public class SpaceWarpConsole : KerbalBehavior
     private static Vector2 _scrollPosition;
     private static Vector2 _scrollView;
 
-    private readonly Queue<string> _debugMessages = new Queue<string>();
+    private readonly Queue<string> _debugMessages = new();
 
-    public void Start()
+    public new void Start()
     {
         if (_loaded)
         {
@@ -32,7 +32,7 @@ public class SpaceWarpConsole : KerbalBehavior
         _loaded = true;
     }
 
-    private void Awake()
+    private new void Awake()
     {
 
         _windowWidth = (int)(Screen.width * 0.5f);
@@ -40,8 +40,7 @@ public class SpaceWarpConsole : KerbalBehavior
 
         _windowRect = new Rect((Screen.width * 0.15f), (Screen.height * 0.15f), 0, 0);
         _scrollPosition = Vector2.zero;
-
-
+        
     }
 
     private void OnGUI()
@@ -56,13 +55,10 @@ public class SpaceWarpConsole : KerbalBehavior
         string header = $"spacewarp.console";
         GUILayoutOption width = GUILayout.Width((float)(_windowWidth * 0.8));
         GUILayoutOption height = GUILayout.Height((float)(_windowHeight * 0.8));
-            
-
+        
         _windowRect = GUILayout.Window(controlID, _windowRect, DrawConsole, header, width, height);
     }
-
-       
-
+    
     private void Update()
     {
         if (Input.GetKey(KeyCode.LeftAlt) && Input.GetKeyDown(KeyCode.C))
@@ -91,9 +87,7 @@ public class SpaceWarpConsole : KerbalBehavior
                 _scrollPosition = _scrollView;
             }
         }
-            
-
-             
+        
         GUILayout.EndScrollView();
         GUILayout.BeginHorizontal();
 


### PR DESCRIPTION
The Awake() method in Unity is a special function that gets called once during the lifetime of a script, when the GameObject that the script is attached to is first activated in the scene.

In the code you provided, public new void Awake() or Start is used to initialize a Rect variable _windowRect with a specific position and size.

The reason for using new in this case is to hide the Awake() method inherited from the base class, and provide a different implementation of the Awake() method specific to this script.

By setting the position and size of _windowRect in Awake(), the script can ensure that the rect is initialized before it is used in other parts of the script. This can be useful for scripts that need to set up some variables or objects before they are used in the scene.

If this is not the intention let me know.

-----------------------------------------------------------------------------------------------------------------------------------

Had some building issues in the latest version I was able to pull and I fixed it by setting the language level to "LATEST" in the csproj. Latest seems to work just fine after some testing.

also are there a specific reason we are using newtonsoft 12.0.1? Asking since that version is compromised.
Can we bump to 13.0.2?


