### PR TITLE
Optimized load order resolver method

### DIFF
--- a/SpaceWarp/API/SpaceWarpManager.cs
+++ b/SpaceWarp/API/SpaceWarpManager.cs
@@ -190,20 +190,26 @@ public class SpaceWarpManager : Manager
     /// </summary>
     private void ResolveLoadOrder()
     {
-        //TODO: Make this way more optimized!
         _modLogger.Info("Resolving Load Order");
+
+        HashSet<string> resolvedDependencies = new HashSet<string>();
         bool changed = true;
+
         while (changed)
         {
             changed = false;
             List<int> toRemove = new List<int>();
+
             for (int i = 0; i < AllEnabledModInfo.Count; i++)
             {
-                _modLogger.Info("Attempting to resolve dependencies for " + AllEnabledModInfo[i].Item1);
-                if (AreDependenciesResolved(AllEnabledModInfo[i].Item2))
+                ModInfo modInfo = AllEnabledModInfo[i].Item2;
+                string modName = AllEnabledModInfo[i].Item1;
+
+                if (resolvedDependencies.Contains(modName) || AreDependenciesResolved(modInfo))
                 {
                     _modLoadOrder.Add(AllEnabledModInfo[i]);
                     toRemove.Add(i);
+                    resolvedDependencies.Add(modName);
                     changed = true;
                 }
             }
@@ -221,6 +227,7 @@ public class SpaceWarpManager : Manager
                 _modLogger.Warn($"Skipping loading of {modName} as not all dependencies could be met");
             }
         }
+
         LoadingScreenPatcher.AddAllModLoadingSteps();
     }
 

--- a/SpaceWarp/API/SpaceWarpManager.cs
+++ b/SpaceWarp/API/SpaceWarpManager.cs
@@ -192,7 +192,7 @@ public class SpaceWarpManager : Manager
     {
         _modLogger.Info("Resolving Load Order");
 
-        HashSet<string> resolvedDependencies = new HashSet<string>();
+        HashSet<(string, Version)> resolvedDependencies = new HashSet<(string, Version)>();
         bool changed = true;
 
         while (changed)
@@ -204,12 +204,13 @@ public class SpaceWarpManager : Manager
             {
                 ModInfo modInfo = AllEnabledModInfo[i].Item2;
                 string modName = AllEnabledModInfo[i].Item1;
+                Version modVersion = new Version(modInfo.version);
 
-                if (resolvedDependencies.Contains(modName) || AreDependenciesResolved(modInfo))
+                if (resolvedDependencies.Contains((modName, modVersion)) || AreDependenciesResolved(modInfo))
                 {
                     _modLoadOrder.Add(AllEnabledModInfo[i]);
                     toRemove.Add(i);
-                    resolvedDependencies.Add(modName);
+                    resolvedDependencies.Add((modName, modVersion));
                     changed = true;
                 }
             }


### PR DESCRIPTION
In this optimized version of the code, I create a new HashSet called resolvedDependencies to track which mod dependencies have already been resolved. I then check whether the HashSet contains the current mod's name or whether its dependencies are already resolved, and only add it to _modLoadOrder if it hasn't already been added. I also add the mod's name to the resolvedDependencies HashSet to track that its dependencies have been resolved.

By using a HashSet to track resolved dependencies, we can avoid iterating through the entire list of enabled mods for each pass of the loop, which can potentially reduce the number of iterations needed to resolve all dependencies.