### PR TITLE
Added loader for lang files

### DIFF
--- a/SpaceWarp/API/SpaceWarpManager.cs
+++ b/SpaceWarp/API/SpaceWarpManager.cs
@@ -715,4 +715,56 @@ public class SpaceWarpManager : Manager
             _modLogger.Info($"Did not find addressables for {modID}");
         }
     }
+
+    private void LoadLocalizationFromFolder(string folder)
+    {
+        _modLogger.Info($"Attempting to load localizations from {folder}");
+        I2.Loc.LanguageSourceData languageSourceData = null;
+        if (!Directory.Exists(folder))
+        {
+            _modLogger.Info($"{folder} does not exist, not loading localizations.");
+            return;
+        }
+        DirectoryInfo info = new DirectoryInfo(folder);
+        foreach (var csvFile in info.GetFiles("*.csv"))
+        {
+            languageSourceData ??= new I2.Loc.LanguageSourceData();
+            var csvData = File.ReadAllText(csvFile.FullName);
+            languageSourceData.Import_CSV("", csvData, I2.Loc.eSpreadsheetUpdateMode.AddNewTerms);
+        }
+
+        foreach (var i2csvFile in info.GetFiles("*.i2csv"))
+        {
+            languageSourceData ??= new I2.Loc.LanguageSourceData();
+            var i2csvData = File.ReadAllText(i2csvFile.FullName);
+            languageSourceData.Import_I2CSV("", i2csvData, I2.Loc.eSpreadsheetUpdateMode.AddNewTerms);
+        }
+
+        if (languageSourceData != null)
+        {
+            _modLogger.Info($"Loaded localizations from {folder}");
+            I2.Loc.LocalizationManager.AddSource(languageSourceData);
+        }
+        else
+        {
+            _modLogger.Info($"No localizations found in {folder}");
+        }
+    }
+    public void LoadSpaceWarpLocalizations()
+    {
+        if (I2.Loc.LocalizationManager.Sources.Count == 0)
+        {
+            I2.Loc.LocalizationManager.UpdateSources();
+        }
+
+        string localizationsPath = Path.Combine(SPACE_WARP_PATH, "localizations");
+        LoadLocalizationFromFolder(localizationsPath);
+    }
+
+    public void LoadSingleModLocalization(string modID, ModInfo info)
+    {
+        string modFolder = Path.Combine(MODS_FULL_PATH, modID);
+        string localizationsPath = Path.Combine(modFolder, "localizations");
+        LoadLocalizationFromFolder(localizationsPath);
+    }
 }

--- a/SpaceWarp/Patching/LoadingActions/LoadLocalizationAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/LoadLocalizationAction.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using KSP.Game.Flow;
+using SpaceWarp.API;
+using SpaceWarp.API.Managers;
+using SpaceWarp.API.Mods.JSON;
+
+namespace SpaceWarp.Patching.LoadingActions;
+
+public class LoadLocalizationAction : FlowAction
+{
+    private string _modID;
+    private ModInfo _info;
+
+    public LoadLocalizationAction(string name, string modID, ModInfo info) : base(name)
+    {
+        _modID = modID;
+        _info = info;
+    }
+
+    public override void DoAction(Action resolve, Action<string> reject)
+    {
+        ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
+
+        try
+        {
+            spaceWarpManager.LoadSingleModLocalization(_modID,_info);
+            resolve();
+        }
+        catch (Exception e)
+        {
+            reject(e.ToString());
+        }
+    }
+}

--- a/SpaceWarp/Patching/LoadingActions/LoadSpaceWarpLocalizationsAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/LoadSpaceWarpLocalizationsAction.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using KSP.Game.Flow;
+using SpaceWarp.API;
+using SpaceWarp.API.Managers;
+
+namespace SpaceWarp.Patching.LoadingActions;
+
+public class LoadSpaceWarpLocalizationsAction : FlowAction
+{
+    public LoadSpaceWarpLocalizationsAction(string name) : base(name)
+    {
+    }
+
+    public override void DoAction(Action resolve, Action<string> reject)
+    {
+        ManagerLocator.TryGet(out SpaceWarpManager spaceWarpManager);
+
+        try
+        {
+            spaceWarpManager.LoadSpaceWarpLocalizations();
+            resolve();
+        }
+        catch (Exception e)
+        {
+            reject(e.ToString());
+        }
+    }
+}

--- a/SpaceWarp/Patching/LoadingScreenPatcher.cs
+++ b/SpaceWarp/Patching/LoadingScreenPatcher.cs
@@ -19,6 +19,8 @@ public class LoadingScreenPatcher
             new LoadSpaceWarpAddressablesAction("Initializing Space Warp Provided Addressables"));
         gameManager.LoadingFlow.AddAction(
             new SpaceWarpAssetInitializationAction("Initializing Space Warp Provided Assets"));
+        gameManager.LoadingFlow.AddAction(
+            new LoadSpaceWarpLocalizationsAction("Initializing Space Warp Localizations"));
     }
 
     public static void AddAllModLoadingSteps()
@@ -31,6 +33,7 @@ public class LoadingScreenPatcher
                 mod.Item1, mod.Item2));
             gameManager.LoadingFlow.AddAction(new LoadAssetAction($"Loading assets for {mod.Item1}", mod.Item1,
                 mod.Item2));
+            gameManager.LoadingFlow.AddAction(new LoadLocalizationAction($"Loading localizations for {mod.Item1}", mod.Item1, mod.Item2));
             gameManager.LoadingFlow.AddAction(new LoadModAction($"Initializing {mod.Item1}", mod.Item1, mod.Item2));
         }
 


### PR DESCRIPTION
Can either be a csv or an i2csv (format specific to the localization library, understanding it is left as an exercise to the reader, it allows for more flexibility, but is massively more complex).

CSV must have unix line endings (lf) windows line endings break it.

Format is 
`Key,Type,Description,Lang1,Lang2`

Place the .csv or .i2csv file into `modid/localizations/` multiple files will be merged together.