### PR TITLE
Debug Console - Colored messages Log Level

### DIFF
--- a/ExampleMod/ExampleMod.cs
+++ b/ExampleMod/ExampleMod.cs
@@ -1,4 +1,5 @@
 ﻿using BepInEx;
+using BepInEx.Logging;
 using SpaceWarp.API.Mods;
 using SpaceWarp.API.Assets;
 using KSP.UI.Binding;
@@ -90,6 +91,9 @@ public class ExampleMod : BaseSpaceWarpPlugin
         GUILayout.Label("Example Mod - Built with Space-Warp");
         GUI.DragWindow(new Rect(0, 0, 10000, 500));
     }
+    
+    private float lastUpdateTime = 0.0f;
+    private float updateInterval = 1.0f;
 
     /// <summary>
     /// Runs every frame and performs various tasks based on the game state.
@@ -97,9 +101,26 @@ public class ExampleMod : BaseSpaceWarpPlugin
     private void LateUpdate()
     {
         // Now lets play with some Game objects
-        if (Game.GlobalGameState.GetState() == KSP.Game.GameState.MainMenu)
+        // Check if the specified interval has elapsed
+        if (Time.time - lastUpdateTime >= updateInterval)
         {
-            KSP.Audio.KSPAudioEventManager.SetMasterVolume(Mathf.Sin(Time.time) * 100);
+            // Update the last update time to the current time
+            lastUpdateTime = Time.time;
+
+            // Now lets play with some Game objects
+            if (Game.GlobalGameState.GetState() == KSP.Game.GameState.MainMenu)
+            {
+                Logger.Log(LogLevel.None, "This is log level none");
+                Logger.Log(LogLevel.Debug, "This is log level debug");
+                Logger.Log(LogLevel.Info, "This is log level info");
+                Logger.Log(LogLevel.Warning, "This is log level warning");
+                Logger.Log(LogLevel.Error, "This is log level error");
+                Logger.Log(LogLevel.Fatal, "This is log level fatal");
+                Logger.Log(LogLevel.Message, "This is log level message");
+                Logger.Log(LogLevel.All, "This is log level all");
+
+                KSP.Audio.KSPAudioEventManager.SetMasterVolume(Mathf.Sin(Time.time) * 100);
+            }
         }
         else if (Game.GlobalGameState.GetState() == KSP.Game.GameState.FlightView)
         {

--- a/SpaceWarp/UI/ModListUI.cs
+++ b/SpaceWarp/UI/ModListUI.cs
@@ -1,5 +1,4 @@
 ﻿using KSP.Game;
-using KSP.UI.Binding;
 using SpaceWarp.API.Mods.JSON;
 using UnityEngine;
 

--- a/SpaceWarp/UI/SpaceWarpConsoleLogListener.cs
+++ b/SpaceWarp/UI/SpaceWarpConsoleLogListener.cs
@@ -6,10 +6,17 @@ namespace SpaceWarp.UI;
 public sealed class SpaceWarpConsoleLogListener : ILogListener
 {
     internal static readonly List<string> DebugMessages = new();
-    
+
     public void LogEvent(object sender, LogEventArgs eventArgs)
     {
-        DebugMessages.Add(eventArgs.ToStringLine());
+        DebugMessages.Add(BuildMessage(eventArgs.Level, eventArgs.Data, eventArgs.Source));
+    }
+
+    private static string BuildMessage(LogLevel level, object data, ILogSource source)
+    {
+        return level == LogLevel.None 
+            ? $"[{(object) source.SourceName}] {data}" 
+            : $"[{(object) level} : {(object) source.SourceName}] {data}";
     }
 
     public void Dispose()


### PR DESCRIPTION
In relation to #119 I propose this PR after working on it for a bit.

Its based of the LogLevel from BepInEx.

I have also changed the **SpaceWarpConsoleLogListener** because the LogEventArgs.toStringLine from BepInEx is hella weird and adds a bunch off super annoying spaces to almost all LogLevels except a selected few I can't remember from the top of my head right now..

It formats the meesages like this:
```
"[LEVEL  :      SENDER] MESSAGE"
```

I made my own custom implementation that formats the messages like this instead
```
"[LEVEL : SENDER] MESSAGE"
```

LogLevel.Fatal => **Color.red** (bold),
LogLevel.Error => Color.red,
LogLevel.Warning => Color.yellow,
LogLevel.Message => Color.white,
LogLevel.Info => Color.cyan,
LogLevel.Debug => Color.green,
LogLevel.All => Color.magenta,

default => style.normal.textColor
