### PR TITLE
Added timestamps to the debug console window

### DIFF
--- a/SpaceWarp/SpaceWarpPlugin.cs
+++ b/SpaceWarp/SpaceWarpPlugin.cs
@@ -29,6 +29,7 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
     internal ConfigEntry<Color> configAllColor;
     internal ConfigEntry<bool> configShowConsoleButton;
     internal ConfigEntry<bool> configShowTimeStamps;
+    internal ConfigEntry<string> configTimeStampFormat;
 
     internal new ManualLogSource Logger => base.Logger;
 
@@ -50,8 +51,10 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
                 "Show console button in app.bar, requires restart");
         configShowTimeStamps = Config.Bind("Debug Console", "Show Timestamps", false, 
             "Show time stamps in debug console");
-
-        BepInEx.Logging.Logger.Listeners.Add(new SpaceWarpConsoleLogListener());
+        configTimeStampFormat = Config.Bind("Debug Console", "Timestamp Format", "HH:mm:ss.fff",
+            "The format for the timestamps in the debug console.");
+        
+        BepInEx.Logging.Logger.Listeners.Add(new SpaceWarpConsoleLogListener(this));
 
         Harmony.CreateAndPatchAll(typeof(SpaceWarpPlugin).Assembly, ModGuid);
         

--- a/SpaceWarp/UI/SpaceWarpConsole.cs
+++ b/SpaceWarp/UI/SpaceWarpConsole.cs
@@ -1,4 +1,5 @@
-﻿using BepInEx.Bootstrap;
+﻿using System;
+using BepInEx.Bootstrap;
 using BepInEx.Logging;
 using KSP.Game;
 using KSP.UI.Binding;
@@ -141,9 +142,12 @@ public sealed class SpaceWarpConsole : KerbalMonoBehaviour
         GUI.DragWindow(new Rect(0, 0, 10000, 500));
     }
 
-    private static LogLevel GetLogLevelFromMessage(string message)
+    private LogLevel GetLogLevelFromMessage(string message)
     {
-        return message.ToLower() switch
+        var logParts = message.ToLower().Replace(" ", "").Split(']');
+        var logLevelIndex = _spaceWarpPluginInstance.configShowTimeStamps.Value ? 1 : 0;
+
+        return logParts[logLevelIndex] switch
         {
             { } logMessage when logMessage.StartsWith("[fatal") => LogLevel.Fatal,
             { } logMessage when logMessage.StartsWith("[error") => LogLevel.Error,

--- a/SpaceWarp/UI/SpaceWarpConsoleLogListener.cs
+++ b/SpaceWarp/UI/SpaceWarpConsoleLogListener.cs
@@ -1,24 +1,37 @@
+using System;
 using System.Collections.Generic;
-using BepInEx.Bootstrap;
 using BepInEx.Logging;
-using UnityEngine;
 
 namespace SpaceWarp.UI;
 
 public sealed class SpaceWarpConsoleLogListener : ILogListener
 {
+    private readonly SpaceWarpPlugin _spaceWarpPluginInstance;
+
     internal static readonly List<string> DebugMessages = new();
+
+    public SpaceWarpConsoleLogListener(SpaceWarpPlugin spaceWarpPluginInstance)
+    {
+        _spaceWarpPluginInstance = spaceWarpPluginInstance;
+    }
 
     public void LogEvent(object sender, LogEventArgs eventArgs)
     {
-        DebugMessages.Add(BuildMessage(eventArgs.Level, eventArgs.Data, eventArgs.Source));
+        DebugMessages.Add(BuildMessage(TimestampMessage(), eventArgs.Level, eventArgs.Data, eventArgs.Source));
     }
 
-    private static string BuildMessage(LogLevel level, object data, ILogSource source)
+    private string TimestampMessage()
+    {
+        return _spaceWarpPluginInstance.configShowTimeStamps.Value
+            ? "[" + DateTime.Now.ToString(_spaceWarpPluginInstance.configTimeStampFormat.Value) + "] "
+            : "";
+    }
+
+    private static string BuildMessage(string timestamp, LogLevel level, object data, ILogSource source)
     {
         return level == LogLevel.None
-            ? $"[{(object) source.SourceName}] {data}"
-            : $"[{(object) level} : {(object) source.SourceName}] {data}";
+            ? $"{timestamp}[{source.SourceName}] {data}"
+            : $"{timestamp}[{level} : {source.SourceName}] {data}";
     }
 
     public void Dispose()


### PR DESCRIPTION
Timestamps are now shown on log messages in the debug console.
![image](https://user-images.githubusercontent.com/5883716/222929061-658c3e44-08f3-453a-8b87-64d73f5226a3.png)
![image](https://user-images.githubusercontent.com/5883716/222929074-bde0a93e-9a32-4011-87da-8744cde21dbb.png)

Timestamps can be toggled on or off and you can change the timestamp format by editing the format string as you like.
https://learn.microsoft.com/en-us/dotnet/standard/base-types/standard-date-and-time-format-strings