### PR TITLE
Basic implementation of a log janitor so we don't run out of memory

### DIFF
--- a/SpaceWarp/SpaceWarpPlugin.cs
+++ b/SpaceWarp/SpaceWarpPlugin.cs
@@ -30,6 +30,7 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
     internal ConfigEntry<bool> configShowConsoleButton;
     internal ConfigEntry<bool> configShowTimeStamps;
     internal ConfigEntry<string> configTimeStampFormat;
+    internal ConfigEntry<int> configDebugMessageLimit;
 
     internal new ManualLogSource Logger => base.Logger;
 
@@ -53,6 +54,8 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
             "Show time stamps in debug console");
         configTimeStampFormat = Config.Bind("Debug Console", "Timestamp Format", "HH:mm:ss.fff",
             "The format for the timestamps in the debug console.");
+        configDebugMessageLimit = Config.Bind("Debug Console", "Message Limit", 1000,
+            "The maximum number of messages to keep in the debug console.");
         
         BepInEx.Logging.Logger.Listeners.Add(new SpaceWarpConsoleLogListener(this));
 

--- a/SpaceWarp/UI/SpaceWarpConsole.cs
+++ b/SpaceWarp/UI/SpaceWarpConsole.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using BepInEx.Bootstrap;
+﻿using BepInEx.Bootstrap;
 using BepInEx.Logging;
 using KSP.Game;
 using KSP.UI.Binding;

--- a/SpaceWarp/UI/SpaceWarpConsoleLogListener.cs
+++ b/SpaceWarp/UI/SpaceWarpConsoleLogListener.cs
@@ -18,6 +18,16 @@ public sealed class SpaceWarpConsoleLogListener : ILogListener
     public void LogEvent(object sender, LogEventArgs eventArgs)
     {
         DebugMessages.Add(BuildMessage(TimestampMessage(), eventArgs.Level, eventArgs.Data, eventArgs.Source));
+        LogMessageJanitor();
+    }
+
+    private void LogMessageJanitor()
+    {
+        var configDebugMessageLimit = _spaceWarpPluginInstance.configDebugMessageLimit.Value;
+        if (DebugMessages.Count > configDebugMessageLimit)
+        {
+            DebugMessages.RemoveRange(0, DebugMessages.Count - configDebugMessageLimit);
+        }
     }
 
     private string TimestampMessage()


### PR DESCRIPTION
Started working on the log janitor that will help us keep the logs cleaned up when they get to big.
This is a basic implementation of a system that will help us not run out of memory if too much stuff is thrown at the log listener.

Once we reach the maximum limit of messages defined in the config (default value 1000) the earliest messages will be deleted to bring the count down to maximum allowed limit. This ensures that the list never grows beyond a certain size.

I will start working on preserving the log messages created during startup in a later patch.