### PR TITLE
Automatically loads labelled language sources from addressables

### DIFF
--- a/SpaceWarp/Patching/BootstrapPatch.cs
+++ b/SpaceWarp/Patching/BootstrapPatch.cs
@@ -44,10 +44,12 @@ internal static class BootstrapPatch
 
             foreach (var plugin in SpaceWarpManager.SpaceWarpPlugins)
             {
-                flow.AddAction(new LoadLocalizationAction(plugin));
                 flow.AddAction(new LoadAddressablesAction(plugin));
+                flow.AddAction(new LoadLocalizationAction(plugin));
                 flow.AddAction(new LoadAssetAction(plugin));
             }
+            
+            flow.AddAction(new LoadAddressablesLocalizationsAction());
             
             foreach (var plugin in SpaceWarpManager.SpaceWarpPlugins)
             {

--- a/SpaceWarp/Patching/LoadingActions/LoadAddressablesLocalizationsAction.cs
+++ b/SpaceWarp/Patching/LoadingActions/LoadAddressablesLocalizationsAction.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using I2.Loc;
+using KSP.Game;
+using KSP.Game.Flow;
+using SpaceWarp.API.Mods;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+
+namespace SpaceWarp.Patching.LoadingActions;
+
+internal sealed class LoadAddressablesLocalizationsAction : FlowAction
+{
+    public LoadAddressablesLocalizationsAction() : base($"Loading localizations from Addressables")
+    {
+    }
+
+    public override void DoAction(Action resolve, Action<string> reject)
+    {
+        try
+        {
+            GameManager.Instance.Game.Assets.LoadByLabel("language_source",
+                OnLanguageSourceAssetLoaded, delegate(IList<LanguageSourceAsset> languageAssetLocations)
+                {
+                    if(languageAssetLocations != null)
+                    {
+                        Addressables.Release(languageAssetLocations);
+                    }
+
+                    resolve();
+                });
+        }
+        catch (Exception e)
+        {
+            Debug.LogError(e.ToString());
+            reject(null);
+        }
+    }
+    
+    private static void OnLanguageSourceAssetLoaded(LanguageSourceAsset asset)
+    {
+        if (!asset || LocalizationManager.Sources.Contains(asset.mSource)) return;
+        asset.mSource.owner = asset;
+        LocalizationManager.AddSource(asset.mSource);
+    }
+}


### PR DESCRIPTION
Any LanguageSourceAsset labelled 'language_source' will now be loaded automatically after all mods assets are loaded, before pre-init, no messing with CSV files. 

Tested working with setting languages/terms manually, likely works with google spreadsheet integrations, but I didn't test that.

Also, now allows for a whole bunch of non-text things to be localized if you want to do that.