### PR TITLE
Version checking

### DIFF
--- a/SpaceWarp/API/Mods/JSON/ModInfo.cs
+++ b/SpaceWarp/API/Mods/JSON/ModInfo.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System.Collections.Generic;
+using JetBrains.Annotations;
 
 namespace SpaceWarp.API.Mods.JSON;
 
@@ -32,4 +33,8 @@ public sealed class ModInfo
 
     [JsonProperty("ksp2_version")]
     public SupportedVersionsInfo SupportedKsp2Versions { get; internal set; }
+
+    [JsonProperty("version_check", Required = Required.AllowNull)]
+    [CanBeNull]
+    public string VersionCheck { get; internal set; }
 }

--- a/SpaceWarp/API/Mods/JSON/SupportedVersionsInfo.cs
+++ b/SpaceWarp/API/Mods/JSON/SupportedVersionsInfo.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace SpaceWarp.API.Mods.JSON;
 
@@ -13,4 +14,53 @@ public sealed class SupportedVersionsInfo
 
     [JsonProperty("max")]
     public string Max { get; internal set; } = "*";
+
+    public bool IsSupported(string toCheck)
+    {
+        try
+        {
+            var minList = Min.Split('.');
+            var maxList = Max.Split('.');
+            var checkList = toCheck.Split('.');
+            var minMin = Math.Min(minList.Length, checkList.Length);
+            var minMax = Math.Max(maxList.Length, checkList.Length);
+            for (var i = 0; i < minMin; i++)
+            {
+                if (minList[i] == "*")
+                {
+                    break;
+                }
+                if (int.Parse(checkList[i]) < int.Parse(minList[i]))
+                {
+                    return false;
+                }
+                if (int.Parse(checkList[i]) > int.Parse(minList[i]))
+                {
+                    break;
+                }
+            }
+
+            for (var i = 0; i < minMax; i++)
+            {
+                if (maxList[i] == "*")
+                {
+                    break;
+                }
+                if (int.Parse(checkList[i]) > int.Parse(minList[i]))
+                {
+                    return false;
+                }
+                if (int.Parse(checkList[i]) < int.Parse(minList[i]))
+                {
+                    break;
+                }
+            }
+
+            return true;
+        }
+        catch
+        {
+            return true;
+        }
+    }
 }

--- a/SpaceWarp/SpaceWarpManager.cs
+++ b/SpaceWarp/SpaceWarpManager.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using BepInEx.Bootstrap;
 using BepInEx.Logging;
+using KSP.Game;
 using Newtonsoft.Json;
 using UnityEngine;
 using SpaceWarp.API.Assets;
@@ -23,6 +24,7 @@ internal static class SpaceWarpManager
     internal static IReadOnlyList<BaseSpaceWarpPlugin> SpaceWarpPlugins;
     internal static ConfigurationManager.ConfigurationManager ConfigurationManager;
     internal static Dictionary<string,bool> ModsOutdated = new();
+    internal static Dictionary<string, bool> ModsUnsupported = new();
     internal static void GetSpaceWarpPlugins()
     {
         
@@ -77,6 +79,17 @@ internal static class SpaceWarpManager
                 AssetManager.TryGetAsset("spacewarp/swconsoleui/spacewarpconsole.guiskin", out _skin);
             }
             return _skin;
+        }
+    }
+
+    
+    internal static void CheckKspVersions()
+    {
+        const string kspVersion = VersionID.VERSION_TEXT;
+        foreach (var plugin in SpaceWarpPlugins)
+        {
+            ModsUnsupported[plugin.SpaceWarpMetadata.ModID] =
+                !plugin.SpaceWarpMetadata.SupportedKsp2Versions.IsSupported(kspVersion);
         }
     }
 }

--- a/SpaceWarp/SpaceWarpManager.cs
+++ b/SpaceWarp/SpaceWarpManager.cs
@@ -22,6 +22,7 @@ internal static class SpaceWarpManager
     internal static string SpaceWarpFolder;
     internal static IReadOnlyList<BaseSpaceWarpPlugin> SpaceWarpPlugins;
     internal static ConfigurationManager.ConfigurationManager ConfigurationManager;
+    internal static Dictionary<string,bool> ModsOutdated = new();
     internal static void GetSpaceWarpPlugins()
     {
         

--- a/SpaceWarp/SpaceWarpPlugin.cs
+++ b/SpaceWarp/SpaceWarpPlugin.cs
@@ -87,11 +87,6 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
         Game.Messages.Subscribe(typeof(GameStateChangedMessage), StateChanges.OnGameStateChanged,false,true);
         
         InitializeUI();
-    }
-
-    public override void OnPostInitialized()
-    {
-        base.OnPostInitialized();
         if (configFirstLaunch.Value)
         {
             configFirstLaunch.Value = false;
@@ -107,8 +102,10 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
         }
         else
         {
-            
+            ClearVersions();
         }
+        
+        SpaceWarpManager.CheckKspVersions();
     }
 
     public void ClearVersions()
@@ -159,7 +156,7 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
     }
     IEnumerator CheckVersion(ModInfo pluginInfo)
     {
-        var www = new UnityWebRequest(pluginInfo.VersionCheck);
+        var www = UnityWebRequest.Get(pluginInfo.VersionCheck);
         yield return www.SendWebRequest();
 
         if (www.result != UnityWebRequest.Result.Success)
@@ -168,6 +165,7 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
         }
         else
         {
+            
             var results = www.downloadHandler.text;
             var checkInfo = JsonConvert.DeserializeObject<ModInfo>(results);
             SpaceWarpManager.ModsOutdated[pluginInfo.ModID] = OlderThan(pluginInfo.Version, checkInfo.Version);

--- a/SpaceWarp/UI/ModListUI.cs
+++ b/SpaceWarp/UI/ModListUI.cs
@@ -19,6 +19,7 @@ public class ModListUI : KerbalMonoBehaviour
     private static Vector2 _scrollPositionMods;
     private static Vector2 _scrollPositionInfo;
     private static GUIStyle _closeButtonStyle;
+    private static GUIStyle _outdatedModStyle;
     
     private const string ModListHeader = "ModListHeader";
 
@@ -62,10 +63,48 @@ public class ModListUI : KerbalMonoBehaviour
             fontSize = 8
         };
 
+        if (_outdatedModStyle != null)
+        {
+            _outdatedModStyle = new GUIStyle(GUI.skin.button)
+            {
+                normal =
+                {
+                    textColor = Color.yellow
+                },
+                active =
+                {
+                    textColor = Color.yellow
+                },
+                hover =
+                {
+                    textColor = Color.yellow
+                },
+                focused =
+                {
+                    textColor = Color.yellow
+                },
+                onActive =
+                {
+                    textColor = Color.yellow
+                },
+                onFocused =
+                {
+                    textColor = Color.yellow
+                },
+                onHover =
+                {
+                    textColor = Color.yellow
+                },
+                onNormal =
+                {
+                    textColor = Color.yellow
+                }
+            };
+        }
+
         int controlID = GUIUtility.GetControlID(FocusType.Passive);
         GUILayoutOption width = GUILayout.Width((float)(_windowWidth * 0.8));
         GUILayoutOption height = GUILayout.Height((float)(_windowHeight * 0.8));
-        GUI.skin = SpaceWarpManager.Skin;
 
         _windowRect = GUILayout.Window(controlID, _windowRect, FillWindow, ModListHeader, width, height);
     }
@@ -107,9 +146,19 @@ public class ModListUI : KerbalMonoBehaviour
         
         foreach (var mod in SpaceWarpManager.SpaceWarpPlugins)
         {
-            if (GUILayout.Button(mod.SpaceWarpMetadata.Name))
+            if (SpaceWarpManager.ModsOutdated[mod.SpaceWarpMetadata.ModID])
             {
-                _selectedMetaData = mod.SpaceWarpMetadata;
+                if (GUILayout.Button(mod.SpaceWarpMetadata.Name, _outdatedModStyle))
+                {
+                    _selectedMetaData = mod.SpaceWarpMetadata;
+                }
+            }
+            else
+            {
+                if (GUILayout.Button(mod.SpaceWarpMetadata.Name))
+                {
+                    _selectedMetaData = mod.SpaceWarpMetadata;
+                }
             }
         }
         GUILayout.EndScrollView();
@@ -120,7 +169,9 @@ public class ModListUI : KerbalMonoBehaviour
             _scrollPositionInfo = GUILayout.BeginScrollView(_scrollPositionInfo, false, false);
             GUILayout.Label($"{_selectedMetaData.Name} (id: {_selectedMetaData.ModID})");
             GUILayout.Label($"Author: {_selectedMetaData.Author}");
-            GUILayout.Label($"Version: {_selectedMetaData.Version}");
+            GUILayout.Label(SpaceWarpManager.ModsOutdated[_selectedMetaData.ModID]
+                ? $"Version: {_selectedMetaData.Version} (outdated)"
+                : $"Version: {_selectedMetaData.Version}");
             GUILayout.Label($"Source: {_selectedMetaData.Source}");
             GUILayout.Label($"Description: {_selectedMetaData.Description}");
             GUILayout.Label($"KSP2 Version: {_selectedMetaData.SupportedKsp2Versions.Min} - {_selectedMetaData.SupportedKsp2Versions.Max}");

--- a/SpaceWarp/UI/ModListUI.cs
+++ b/SpaceWarp/UI/ModListUI.cs
@@ -20,6 +20,7 @@ public class ModListUI : KerbalMonoBehaviour
     private static Vector2 _scrollPositionInfo;
     private static GUIStyle _closeButtonStyle;
     private static GUIStyle _outdatedModStyle;
+    private static GUIStyle _unsupportedModStyle;
     
     private const string ModListHeader = "ModListHeader";
 
@@ -63,44 +64,76 @@ public class ModListUI : KerbalMonoBehaviour
             fontSize = 8
         };
 
-        if (_outdatedModStyle != null)
+        _outdatedModStyle ??= new GUIStyle(GUI.skin.button)
         {
-            _outdatedModStyle = new GUIStyle(GUI.skin.button)
+            normal =
             {
-                normal =
-                {
-                    textColor = Color.yellow
-                },
-                active =
-                {
-                    textColor = Color.yellow
-                },
-                hover =
-                {
-                    textColor = Color.yellow
-                },
-                focused =
-                {
-                    textColor = Color.yellow
-                },
-                onActive =
-                {
-                    textColor = Color.yellow
-                },
-                onFocused =
-                {
-                    textColor = Color.yellow
-                },
-                onHover =
-                {
-                    textColor = Color.yellow
-                },
-                onNormal =
-                {
-                    textColor = Color.yellow
-                }
-            };
-        }
+                textColor = Color.yellow
+            },
+            active =
+            {
+                textColor = Color.yellow
+            },
+            hover =
+            {
+                textColor = Color.yellow
+            },
+            focused =
+            {
+                textColor = Color.yellow
+            },
+            onActive =
+            {
+                textColor = Color.yellow
+            },
+            onFocused =
+            {
+                textColor = Color.yellow
+            },
+            onHover =
+            {
+                textColor = Color.yellow
+            },
+            onNormal =
+            {
+                textColor = Color.yellow
+            }
+        };
+        _unsupportedModStyle ??= new GUIStyle(GUI.skin.button)
+        {
+            normal =
+            {
+                textColor = Color.red
+            },
+            active =
+            {
+                textColor = Color.red
+            },
+            hover =
+            {
+                textColor = Color.red
+            },
+            focused =
+            {
+                textColor = Color.red
+            },
+            onActive =
+            {
+                textColor = Color.red
+            },
+            onFocused =
+            {
+                textColor = Color.red
+            },
+            onHover =
+            {
+                textColor = Color.red
+            },
+            onNormal =
+            {
+                textColor = Color.red
+            }
+        };
 
         int controlID = GUIUtility.GetControlID(FocusType.Passive);
         GUILayoutOption width = GUILayout.Width((float)(_windowWidth * 0.8));
@@ -146,7 +179,15 @@ public class ModListUI : KerbalMonoBehaviour
         
         foreach (var mod in SpaceWarpManager.SpaceWarpPlugins)
         {
-            if (SpaceWarpManager.ModsOutdated[mod.SpaceWarpMetadata.ModID])
+            if (SpaceWarpManager.ModsUnsupported[mod.SpaceWarpMetadata.ModID])
+            {
+                
+                if (GUILayout.Button(mod.SpaceWarpMetadata.Name, _unsupportedModStyle))
+                {
+                    _selectedMetaData = mod.SpaceWarpMetadata;
+                }
+            }
+            else if (SpaceWarpManager.ModsOutdated[mod.SpaceWarpMetadata.ModID])
             {
                 if (GUILayout.Button(mod.SpaceWarpMetadata.Name, _outdatedModStyle))
                 {
@@ -174,7 +215,7 @@ public class ModListUI : KerbalMonoBehaviour
                 : $"Version: {_selectedMetaData.Version}");
             GUILayout.Label($"Source: {_selectedMetaData.Source}");
             GUILayout.Label($"Description: {_selectedMetaData.Description}");
-            GUILayout.Label($"KSP2 Version: {_selectedMetaData.SupportedKsp2Versions.Min} - {_selectedMetaData.SupportedKsp2Versions.Max}");
+            GUILayout.Label(SpaceWarpManager.ModsUnsupported[_selectedMetaData.ModID] ? $"KSP2 Version: {_selectedMetaData.SupportedKsp2Versions.Min} - {_selectedMetaData.SupportedKsp2Versions.Max} (unsupported)" : $"KSP2 Version: {_selectedMetaData.SupportedKsp2Versions.Min} - {_selectedMetaData.SupportedKsp2Versions.Max}");
             GUILayout.Label($"Dependencies");
 
             foreach (DependencyInfo dependency in _selectedMetaData.Dependencies)

--- a/SpaceWarp/UI/VersionCheckPrompt.cs
+++ b/SpaceWarp/UI/VersionCheckPrompt.cs
@@ -18,8 +18,8 @@ internal class VersionCheckPrompt : MonoBehaviour
         float screenRatio = (float) Screen.width / (float) Screen.height;
         float scaleFactor = Mathf.Clamp(screenRatio, minResolution, maxResolution);
 
-        _windowWidth = (int) (Screen.width * 0.5f * scaleFactor);
-        _windowHeight = (int) (Screen.height * 0.5f * scaleFactor);
+        _windowWidth = (int) (Screen.width * 0.2f * scaleFactor);
+        _windowHeight = 0;
         _windowRect = new Rect(
             Screen.width * 0.15f,
             Screen.height * 0.15f,

--- a/SpaceWarp/UI/VersionCheckPrompt.cs
+++ b/SpaceWarp/UI/VersionCheckPrompt.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using UnityEngine;
+
+namespace SpaceWarp.UI;
+
+internal class VersionCheckPrompt : MonoBehaviour
+{
+    public SpaceWarpPlugin spaceWarpPlugin;
+    private GUIStyle _closeButtonStyle;
+    private Rect _windowRect;
+    private float _windowWidth;
+    private float _windowHeight;
+
+    private void Awake()
+    {
+        float minResolution = 1280f / 720f; 
+        float maxResolution = 2048f / 1080f;
+        float screenRatio = (float) Screen.width / (float) Screen.height;
+        float scaleFactor = Mathf.Clamp(screenRatio, minResolution, maxResolution);
+
+        _windowWidth = (int) (Screen.width * 0.5f * scaleFactor);
+        _windowHeight = (int) (Screen.height * 0.5f * scaleFactor);
+        _windowRect = new Rect(
+            Screen.width * 0.15f,
+            Screen.height * 0.15f,
+            Screen.width * 0.5f * scaleFactor,
+            Screen.height * 0.5f * scaleFactor
+        );
+    }
+    public void OnGUI()
+    {
+        GUI.skin = SpaceWarp.API.UI.Skins.ConsoleSkin;
+
+        int controlID = GUIUtility.GetControlID(FocusType.Passive);
+        GUILayoutOption width = GUILayout.Width((float)(_windowWidth * 0.8));
+        GUILayoutOption height = GUILayout.Height((float)(_windowHeight * 0.8));
+
+        _closeButtonStyle ??= new GUIStyle(GUI.skin.button)
+        {
+            fontSize = 8
+        };
+        _windowRect = GUILayout.Window(controlID, _windowRect, FillWindow, "Space Warp", width, height);
+    }
+
+    private void FillWindow(int windowID)
+    {
+        if (GUI.Button(new Rect(_windowRect.width - 18, 2, 16, 16), "x", _closeButtonStyle))
+        {
+            Destroy(this);
+            GUIUtility.ExitGUI();
+        }
+
+        GUILayout.BeginVertical();
+        GUILayout.Label("Allow Space Warp to check versions for mods");
+        GUILayout.BeginHorizontal();
+        if (GUILayout.Button("Yes"))
+        {
+            spaceWarpPlugin.CheckVersions();
+            spaceWarpPlugin.configCheckVersions.Value = true;
+            Destroy(this);
+        }
+
+        if (GUILayout.Button("No"))
+        {
+            Destroy(this);
+        }
+        
+        GUILayout.EndHorizontal();
+        GUILayout.EndVertical();
+        GUI.DragWindow();
+    }
+}

--- a/SpaceWarpBuildTemplate/swinfo.json
+++ b/SpaceWarpBuildTemplate/swinfo.json
@@ -4,7 +4,8 @@
   "author": "Space-Warp Team",
   "description": "Space-Warp is an API for KSP2 mod developers.",
   "source": "https://github.com/SpaceWarpDev/SpaceWarp",
-  "version": "0.4.0",
+  "version_check": "https://raw.githubusercontent.com/SpaceWarpDev/SpaceWarp/main/SpaceWarpBuildTemplate/swinfo.json",
+  "version": "1.0.0",
   "dependencies": [],
   "ksp2_version": {
     "min": "0",


### PR DESCRIPTION
Added code to check mod versions against an online hosted version w/ a prompt to the user on first launch, and configurable in the Configuration Window
Mod version checking is done by checking the optional `check_version` url field of `swinfo.json`
Out of date mods are displayed as yellow in the mod window w/ a outdated note in parentheses next to the version
This also adds checking for KSP2 version for mods, which displays as red in the mod window with unsupported in parentheses next to the mods ksp to version when it detects that the mod does not support the current KSP 2 version.
It also adds the version check into the swinfo.json file and ups its version number to 1.0.0