### PR TITLE
Start providing extensions for getting parts and such.

### DIFF
--- a/SpaceWarp/API/Game/Extensions/PartProviderExtensions.cs
+++ b/SpaceWarp/API/Game/Extensions/PartProviderExtensions.cs
@@ -1,0 +1,17 @@
+﻿using KSP.Game;
+using KSP.Sim.Definitions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpaceWarp.API.Game.Extensions;
+
+public static class PartProviderExtensions
+{
+    public static IEnumerable<PartCore> WithModule<T>(this PartProvider provider) where T : ModuleData
+    {
+        return provider._partData.Values.Where(part => part.modules.OfType<T>().Count() > 0);
+    }
+}


### PR DESCRIPTION
This provides a method to get all parts w/ a module from a PartProvider.
So now to get parts w/ a module you can do
```cs
Game.Instance.Parts.WithModule<Antenna>();
```