### PR TITLE
Add an API for adding items to SequentialFlows

### DIFF
--- a/SpaceWarp/API/Loading/SaveLoad.cs
+++ b/SpaceWarp/API/Loading/SaveLoad.cs
@@ -1,0 +1,298 @@
+﻿using KSP.Game.Flow;
+using SpaceWarp.Patching;
+
+namespace SpaceWarp.API.Loading;
+
+public static class SaveLoad
+{
+    /// <summary>
+    ///     <para>Construct and add a <cref>FlowAction</cref> to the Game's load sequence.</para>
+    ///     
+    ///     <para>FlowActionType must have a public constructor that takes either no arguments,
+    ///     or a single GameManager.</para>
+    ///     
+    ///     <para>The action will be run after the first FlowAction with a name equal to referenceAction.
+    ///     If referenceAction is <c>null</c>, the action will be the first action run.</para>
+    ///     
+    ///     <para>
+    ///         The FlowActions that occur in this sequence by default are: (Updated for KSP 0.1.1.0)
+    ///         <list type="number">
+    ///             <item><c>"Creating Splash Screens Prefab"</c></item>
+    ///             <item><c>"Set Loading Optimizations"</c></item>
+    ///             <item><c>"Initialize Addressables system"</c></item>
+    ///             <item><c>"Creating Game Instance"</c></item>
+    ///             <item><c>"Initializing Game Instance"</c></item>
+    ///             <item><c>"Creating Graphics Manager"</c></item>
+    ///             <item><c>"Creating Main Menu"</c></item>
+    ///             <item><c>"Load UI Background Scenes"</c></item>
+    ///             <item><c>"Parsing Loading Screens"</c></item>
+    ///             <item><c>"Set Loading Optimizations"</c></item>
+    ///             <item><c>"loading addressable localizations"</c> (Added by SpaceWarp)</item>
+    ///         </list>
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="FlowActionType">The type of FlowAction to insert</typeparam>
+    /// <param name="referenceAction">The name of the action to insert a FlowActionType after. Use <c>null</c> to insert it at the start.</param>
+    /// <exception cref="InvalidOperationException">Thrown if <c>FlowActionType</c> does not have a valid Constructor</exception>
+    public static void AddFlowActionToGameLoadAfter<FlowActionType>(string referenceAction) where FlowActionType : FlowAction
+    {
+        SequentialFlowLoadersPatcher.AddConstructor(referenceAction, typeof(FlowActionType), SequentialFlowLoadersPatcher.FLOW_METHOD_STARTGAME);
+    }
+
+    /// <summary>
+    ///     <para>Add a <cref>FlowAction</cref> to the Game's load sequence.</para>
+    ///     
+    ///     <para>The action will be run after the first FlowAction with a name equal to referenceAction.
+    ///     If referenceAction is <c>null</c>, the action will be the first action run.</para>
+    ///     
+    ///     <para>
+    ///         The FlowActions that occur in this sequence by default are: (Updated for KSP 0.1.1.0)
+    ///         <list type="number">
+    ///             <item><c>"Creating Splash Screens Prefab"</c></item>
+    ///             <item><c>"Set Loading Optimizations"</c></item>
+    ///             <item><c>"Initialize Addressables system"</c></item>
+    ///             <item><c>"Creating Game Instance"</c></item>
+    ///             <item><c>"Initializing Game Instance"</c></item>
+    ///             <item><c>"Creating Graphics Manager"</c></item>
+    ///             <item><c>"Creating Main Menu"</c></item>
+    ///             <item><c>"Load UI Background Scenes"</c></item>
+    ///             <item><c>"Parsing Loading Screens"</c></item>
+    ///             <item><c>"Set Loading Optimizations"</c></item>
+    ///             <item><c>"loading addressable localizations"</c> (Added by SpaceWarp)</item>
+    ///         </list>
+    ///     </para>
+    /// </summary>
+    /// <param name="flowAction">The FlowAction to insert</param>
+    /// <param name="referenceAction">The name of the action to insert a FlowActionType after. Use <c>null</c> to insert it at the start.</param>
+    public static void AddFlowActionToGameLoadAfter(FlowAction flowAction, string referenceAction)
+    {
+        SequentialFlowLoadersPatcher.AddFlowAction(referenceAction, flowAction, SequentialFlowLoadersPatcher.FLOW_METHOD_STARTGAME);
+    }
+
+    /// <summary>
+    ///     <para>Add a <cref>FlowAction</cref> to the save file loading sequence. A new <c>FlowActionType</c> is constructed every load.</para>
+    ///     
+    ///     <para>
+    ///         FlowActionType must have a public constructor that at most one of each of the following types:
+    ///         <list type="bullet">
+    ///             <item><cref>SaveLoadManager</cref></item>
+    ///             <item><cref>LoadOrSaveCampaignTicket</cref></item>
+    ///             <item><cref>LoadGameData</cref></item>
+    ///         </list>
+    ///     </para>
+    ///     
+    ///     <para>The action will be run after the first FlowAction with a name equal to referenceAction.
+    ///     If referenceAction is <c>null</c>, the action will be the first action run.</para>
+    ///     
+    ///     <para>
+    ///         The FlowActions that occur in this sequence by default are: (Updated for KSP 0.1.1.0)
+    ///         <list type="number">
+    ///             <item><c>"Deserializing Save File Contents"</c></item>
+    ///             <item><c>"Starting..."</c></item>
+    ///             <item><c>"Loading session manager data"</c></item>
+    ///             <item><c>"Set Loading Optimizations"</c></item>
+    ///             <item><c>"Setup local player"</c></item>
+    ///             <item><c>"Load Session Guid"</c></item>
+    ///             <item><c>"Loading KSP2 mission base"</c></item>
+    ///             <item><c>"Load Campaign Players"</c></item>
+    ///             <item><c>"Load Agencies"</c></item>
+    ///             <item><c>"Load Fixup Player And Agency"</c></item>
+    ///             <item><c>"Setup OAB Part Seed Counter"</c></item>
+    ///             <item><c>"Unload Main Menu"</c></item>
+    ///             <item><c>"Validating Version Number"</c></item>
+    ///             <item><c>"Initializing Session Data"</c></item>
+    ///             <item><c>"Load required assets"</c></item>
+    ///             <item><c>"Parsing resource assets"</c></item>
+    ///             <item><c>"Freezing resource definition database"</c></item>
+    ///             <item><c>"Parsing procedural part assets"</c></item>
+    ///             <item><c>"Freezing procedural part definition database"</c></item>
+    ///             <item><c>"Loading Kerbal Prefab Data"</c></item>
+    ///             <item><c>"Loading Kerbal Roster Data"</c></item>
+    ///             <item><c>"Loading Colony Data"</c></item>
+    ///             <item><c>"Setup Properties"</c></item>
+    ///             <item><c>"Creating Simulation"</c></item>
+    ///             <item><c>"Loading Celestial Body Data"</c></item>
+    ///             <item><c>"Parsing interstellar universe"</c></item>
+    ///             <item><c>"Parsing parts text assets"</c></item>
+    ///             <item><c>"Creating Celestial Bodies"</c></item>
+    ///             <item><c>"Pumping Sim Once"</c></item>
+    ///             <item><c>"Creating Universe"</c></item>
+    ///             <item><c>"Creating ViewController"</c></item>
+    ///             <item><c>"Pumping Sim Once"</c></item>
+    ///             <item><c>"Spawning initial local-space body..."</c></item>
+    ///             <item><c>"Loading Map Systems"</c></item>
+    ///             <item><c>"Loading UI Manager"</c></item>
+    ///             <item><c>"Loading KSP2 missions"</c></item>
+    ///             <item><c>"Setting Universe State"</c></item>
+    ///             <item><c>"Creating Vessel"</c></item>
+    ///             <item><c>"Set Active Vessel for Local Player"</c></item>
+    ///             <item><c>"Loading Travel Log Data"</c></item>
+    ///             <item><c>"Pumping Sim Once"</c></item>
+    ///             <item><c>"Loading dashboard for the user"</c></item>
+    ///             <item><c>"Setting Camera State"</c></item>
+    ///             <item><c>"Starting Sim"</c></item>
+    ///             <item><c>"Pumping Sim Once"</c></item>
+    ///             <item><c>"Applying flight control state"</c></item>
+    ///             <item><c>"Applying legacy module data to vessel parts"</c></item>
+    ///             <item><c>"Load Planted Flags"</c></item>
+    ///             <item><c>"Wait for async handles"</c></item>
+    ///             <item><c>"Load Done"</c></item>
+    ///             <item><c>"Set Loading Optimizations"</c></item>
+    ///             <item><c>"Ending..."</c></item>
+    ///         </list>
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="FlowActionType">The type of FlowAction to insert</typeparam>
+    /// <param name="referenceAction">The name of the action to insert a FlowActionType after. Use <c>null</c> to insert it at the start.</param>
+    /// <exception cref="InvalidOperationException">Thrown if <c>FlowActionType</c> does not have a valid Constructor</exception>
+    public static void AddFlowActionToCampaignLoadAfter<FlowActionType>(string referenceAction) where FlowActionType : FlowAction
+    {
+        SequentialFlowLoadersPatcher.AddConstructor(referenceAction, typeof(FlowActionType), SequentialFlowLoadersPatcher.FLOW_METHOD_PRIVATELOADCOMMON);
+    }
+
+    /// <summary>
+    ///     <para>Add a <cref>FlowAction</cref> to the save file loading sequence. The same object is used for every load.</para>
+    ///     
+    ///     <para>The action will be run after the first FlowAction with a name equal to referenceAction.
+    ///     If referenceAction is <c>null</c>, the action will be the first action run.</para>
+    ///     
+    ///     <para>
+    ///         The FlowActions that occur in this sequence by default are: (Updated for KSP 0.1.1.0)
+    ///         <list type="number">
+    ///             <item><c>"Deserializing Save File Contents"</c></item>
+    ///             <item><c>"Starting..."</c></item>
+    ///             <item><c>"Loading session manager data"</c></item>
+    ///             <item><c>"Set Loading Optimizations"</c></item>
+    ///             <item><c>"Setup local player"</c></item>
+    ///             <item><c>"Load Session Guid"</c></item>
+    ///             <item><c>"Loading KSP2 mission base"</c></item>
+    ///             <item><c>"Load Campaign Players"</c></item>
+    ///             <item><c>"Load Agencies"</c></item>
+    ///             <item><c>"Load Fixup Player And Agency"</c></item>
+    ///             <item><c>"Setup OAB Part Seed Counter"</c></item>
+    ///             <item><c>"Unload Main Menu"</c></item>
+    ///             <item><c>"Validating Version Number"</c></item>
+    ///             <item><c>"Initializing Session Data"</c></item>
+    ///             <item><c>"Load required assets"</c></item>
+    ///             <item><c>"Parsing resource assets"</c></item>
+    ///             <item><c>"Freezing resource definition database"</c></item>
+    ///             <item><c>"Parsing procedural part assets"</c></item>
+    ///             <item><c>"Freezing procedural part definition database"</c></item>
+    ///             <item><c>"Loading Kerbal Prefab Data"</c></item>
+    ///             <item><c>"Loading Kerbal Roster Data"</c></item>
+    ///             <item><c>"Loading Colony Data"</c></item>
+    ///             <item><c>"Setup Properties"</c></item>
+    ///             <item><c>"Creating Simulation"</c></item>
+    ///             <item><c>"Loading Celestial Body Data"</c></item>
+    ///             <item><c>"Parsing interstellar universe"</c></item>
+    ///             <item><c>"Parsing parts text assets"</c></item>
+    ///             <item><c>"Creating Celestial Bodies"</c></item>
+    ///             <item><c>"Pumping Sim Once"</c></item>
+    ///             <item><c>"Creating Universe"</c></item>
+    ///             <item><c>"Creating ViewController"</c></item>
+    ///             <item><c>"Pumping Sim Once"</c></item>
+    ///             <item><c>"Spawning initial local-space body..."</c></item>
+    ///             <item><c>"Loading Map Systems"</c></item>
+    ///             <item><c>"Loading UI Manager"</c></item>
+    ///             <item><c>"Loading KSP2 missions"</c></item>
+    ///             <item><c>"Setting Universe State"</c></item>
+    ///             <item><c>"Creating Vessel"</c></item>
+    ///             <item><c>"Set Active Vessel for Local Player"</c></item>
+    ///             <item><c>"Loading Travel Log Data"</c></item>
+    ///             <item><c>"Pumping Sim Once"</c></item>
+    ///             <item><c>"Loading dashboard for the user"</c></item>
+    ///             <item><c>"Setting Camera State"</c></item>
+    ///             <item><c>"Starting Sim"</c></item>
+    ///             <item><c>"Pumping Sim Once"</c></item>
+    ///             <item><c>"Applying flight control state"</c></item>
+    ///             <item><c>"Applying legacy module data to vessel parts"</c></item>
+    ///             <item><c>"Load Planted Flags"</c></item>
+    ///             <item><c>"Wait for async handles"</c></item>
+    ///             <item><c>"Load Done"</c></item>
+    ///             <item><c>"Set Loading Optimizations"</c></item>
+    ///             <item><c>"Ending..."</c></item>
+    ///         </list>
+    ///     </para>
+    /// </summary>
+    /// <param name="flowAction">The FlowAction to insert</param>
+    /// <param name="referenceAction">The name of the action to insert a FlowActionType after. Use <c>null</c> to insert it at the start.</param>
+    public static void AddFlowActionToCampaignLoadAfter(FlowAction flowAction, string referenceAction)
+    {
+        SequentialFlowLoadersPatcher.AddFlowAction(referenceAction, flowAction, SequentialFlowLoadersPatcher.FLOW_METHOD_PRIVATELOADCOMMON);
+    }
+
+    /// <summary>
+    ///     <para>Add a <cref>FlowAction</cref> to the save file writing sequence. A new <c>FlowActionType</c> is constructed every load.</para>
+    ///     
+    ///     <para>
+    ///         FlowActionType must have a public constructor that at most one of each of the following types:
+    ///         <list type="bullet">
+    ///             <item><cref>SaveLoadManager</cref></item>
+    ///             <item><cref>LoadOrSaveCampaignTicket</cref></item>
+    ///         </list>
+    ///     </para>
+    ///     
+    ///     <para>The action will be run after the first FlowAction with a name equal to referenceAction.
+    ///     If referenceAction is <c>null</c>, the action will be the first action run.</para>
+    ///     
+    ///     <para>
+    ///         The FlowActions that occur in this sequence by default are: (Updated for KSP 0.1.1.0)
+    ///         <list type="number">
+    ///             <item><c>"Collecting vessel data for serialization"</c></item>
+    ///             <item><c>"Saving session manager"</c></item>
+    ///             <item><c>"Setting version"</c></item>
+    ///             <item><c>"Saving session guid"</c></item>
+    ///             <item><c>"Collecting game session metadata"</c></item>
+    ///             <item><c>"Saving Kerbal roster"</c></item>
+    ///             <item><c>"Saving colony data"</c></item>
+    ///             <item><c>"Saving Travel Log"</c></item>
+    ///             <item><c>"Collecting mission data for serialization"</c></item>
+    ///             <item><c>"Collecting OAB workspace data for serialization"</c></item>
+    ///             <item><c>"Saving planted flags"</c></item>
+    ///             <item><c>"Saving agencies"</c></item>
+    ///             <item><c>"Saving campaign players"</c></item>
+    ///             <item><c>"Serializing Save File Contents"</c></item>
+    ///         </list>
+    ///     </para>
+    /// </summary>
+    /// <typeparam name="FlowActionType">The type of FlowAction to insert</typeparam>
+    /// <param name="referenceAction">The name of the action to insert a FlowActionType after. Use <c>null</c> to insert it at the start.</param>
+    /// <exception cref="InvalidOperationException">Thrown if <c>FlowActionType</c> does not have a valid Constructor</exception>
+    public static void AddFlowActionToCampaignSaveAfter<FlowActionType>(string referenceAction) where FlowActionType : FlowAction
+    {
+        SequentialFlowLoadersPatcher.AddConstructor(referenceAction, typeof(FlowActionType), SequentialFlowLoadersPatcher.FLOW_METHOD_PRIVATESAVECOMMON);
+    }
+
+    /// <summary>
+    ///     <para>Add a <cref>FlowAction</cref> to the save file writing sequence. The same object is used for every load.</para>
+    ///     
+    ///     <para>The action will be run after the first FlowAction with a name equal to referenceAction.
+    ///     If referenceAction is <c>null</c>, the action will be the first action run.</para>
+    ///     
+    ///     <para>
+    ///         The FlowActions that occur in this sequence by default are: (Updated for KSP 0.1.1.0)
+    ///         <list type="number">
+    ///             <item><c>"Collecting vessel data for serialization"</c></item>
+    ///             <item><c>"Saving session manager"</c></item>
+    ///             <item><c>"Setting version"</c></item>
+    ///             <item><c>"Saving session guid"</c></item>
+    ///             <item><c>"Collecting game session metadata"</c></item>
+    ///             <item><c>"Saving Kerbal roster"</c></item>
+    ///             <item><c>"Saving colony data"</c></item>
+    ///             <item><c>"Saving Travel Log"</c></item>
+    ///             <item><c>"Collecting mission data for serialization"</c></item>
+    ///             <item><c>"Collecting OAB workspace data for serialization"</c></item>
+    ///             <item><c>"Saving planted flags"</c></item>
+    ///             <item><c>"Saving agencies"</c></item>
+    ///             <item><c>"Saving campaign players"</c></item>
+    ///             <item><c>"Serializing Save File Contents"</c></item>
+    ///         </list>
+    ///     </para>
+    /// </summary>
+    /// <param name="flowAction">The FlowAction to insert</param>
+    /// <param name="referenceAction">The name of the action to insert a FlowActionType after. Use <c>null</c> to insert it at the start.</param>
+    public static void AddFlowActionToCampaignSaveAfter(FlowAction flowAction, string referenceAction)
+    {
+        SequentialFlowLoadersPatcher.AddFlowAction(referenceAction, flowAction, SequentialFlowLoadersPatcher.FLOW_METHOD_PRIVATESAVECOMMON);
+    }
+}

--- a/SpaceWarp/Patching/CodeGenerationUtilities.cs
+++ b/SpaceWarp/Patching/CodeGenerationUtilities.cs
@@ -1,0 +1,33 @@
+﻿using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SpaceWarp.Patching;
+
+internal static class CodeGenerationUtilities
+{
+    /// <summary>
+    ///     Creates a CodeInstruction that pushed an integer to the stack.
+    /// </summary>
+    /// <param name="i">The integer to push</param>
+    /// <returns>An new CodeInstruction to push i</returns>
+    internal static CodeInstruction PushIntInstruction(int i)
+    {
+        switch (i) {
+            case 0: return new(OpCodes.Ldc_I4_0);
+            case 1: return new(OpCodes.Ldc_I4_1);
+            case 2: return new(OpCodes.Ldc_I4_2);
+            case 3: return new(OpCodes.Ldc_I4_3);
+            case 4: return new(OpCodes.Ldc_I4_4);
+            case 5: return new(OpCodes.Ldc_I4_5);
+            case 6: return new(OpCodes.Ldc_I4_6);
+            case 7: return new(OpCodes.Ldc_I4_7);
+            case 8: return new(OpCodes.Ldc_I4_8);
+            default: return new(OpCodes.Ldc_I4, i);
+        }
+    }
+}

--- a/SpaceWarp/Patching/SequentialFlowLoadersPatcher.cs
+++ b/SpaceWarp/Patching/SequentialFlowLoadersPatcher.cs
@@ -1,0 +1,276 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+using System.Threading.Tasks;
+using BepInEx.Logging;
+using HarmonyLib;
+using KSP.Game;
+using KSP.Game.Flow;
+using Newtonsoft.Json.Linq;
+using static MoonSharp.Interpreter.Debugging.DebuggerAction;
+
+namespace SpaceWarp.Patching;
+
+[HarmonyPatch]
+internal static class SequentialFlowLoadersPatcher
+{
+    internal const int FLOW_METHOD_STARTGAME = 0;
+    internal const int FLOW_METHOD_PRIVATELOADCOMMON = 1;
+    internal const int FLOW_METHOD_PRIVATESAVECOMMON = 2;
+
+    static SequentialFlowAdditions[] sequentialFlowAdditions = new SequentialFlowAdditions[]
+    {
+        new(typeof(GameManager).GetMethod("StartGame")), // Must be index FLOW_METHOD_STARTGAME
+        new(AccessTools.Method("KSP.Game.SaveLoadManager:PrivateLoadCommon")), // Must be index FLOW_METHOD_PRIVATELOADCOMMON
+        new(AccessTools.Method("KSP.Game.SaveLoadManager:PrivateSaveCommon")), // Must be index FLOW_METHOD_PRIVATESAVECOMMON
+    };
+
+    internal static void AddConstructor(string after, Type flowAction, int methodIndex)
+    {
+        sequentialFlowAdditions[methodIndex].AddConstructor(after, flowAction);
+    }
+
+    internal static void AddFlowAction(string after, FlowAction flowAction, int methodIndex)
+    {
+        sequentialFlowAdditions[methodIndex].AddAction(after, flowAction);
+    }
+
+    public static SequentialFlow Apply(SequentialFlow flow, object[] methodArguments, int methodIndex)
+    {
+        sequentialFlowAdditions[methodIndex].ApplyTo(flow, methodArguments);
+        return flow;
+    }
+
+    static IEnumerable<CodeInstruction> TranspileSequentialFlowBuilderMethod(IEnumerable<CodeInstruction> instructions, int methodIndex)
+    {
+        var StartFlow = typeof(SequentialFlow).GetMethod("StartFlow");
+
+        foreach (CodeInstruction instruction in instructions)
+        {
+            if (instruction.opcode == OpCodes.Callvirt && StartFlow == (MethodInfo)instruction.operand)
+            {
+                // Call to StartFlow found!
+                // Before it occurs, insert any extra flow actions.
+
+                // Get list of relevant arguments to pass to FlowAction constructors.
+                // `parameterCount` has a `+ 1` because `GetParameters()` doesn't include the instance parameter (this).
+                var parameters = sequentialFlowAdditions[methodIndex].method.GetParameters().Where(parameter => !parameter.ParameterType.IsValueType).ToArray();
+                var parameterCount = parameters.Length + 1;
+
+                // Creation of argument `methodArguments` to `Apply()`:
+
+                // Construct an array to hold the arguments.
+                yield return CodeGenerationUtilities.PushIntInstruction(parameterCount);
+                yield return new(OpCodes.Newarr, typeof(object));
+
+                // Assign `this` to element 0.
+                yield return new(OpCodes.Dup);
+                yield return new(OpCodes.Ldc_I4_0);
+                yield return new(OpCodes.Ldarg_0);
+                yield return new(OpCodes.Stelem_Ref);
+
+                // Assign the other arguments.
+                for (int i = 1; i < parameterCount; i++)
+                {
+                    var parameter = parameters[i - 1];
+                    yield return new(OpCodes.Dup);
+                    yield return CodeGenerationUtilities.PushIntInstruction(i);
+                    yield return new(OpCodes.Ldarg_S, (byte)(parameter.Position + 1));
+                    yield return new(OpCodes.Stelem_Ref);
+                }
+
+                // Creation of argument `methodIndex` to `Apply()`:
+                yield return CodeGenerationUtilities.PushIntInstruction(methodIndex);
+
+                // Call `Apply()`.
+                // `flow` is already on the stack and does not need to be created.
+                yield return new(OpCodes.Call, typeof(SequentialFlowLoadersPatcher).GetMethod("Apply"));
+            }
+
+            // Copy everything else.
+            yield return instruction;
+        }
+    }
+
+    [HarmonyPatch(typeof(GameManager))]
+    [HarmonyPatch("StartGame")]
+    [HarmonyPrefix]
+    public static void PrefixGameManagerStartGame(GameManager __instance)
+    {
+        sequentialFlowAdditions[FLOW_METHOD_STARTGAME].ApplyTo(__instance.LoadingFlow, new object[] { __instance });
+    }
+
+    [HarmonyPatch(typeof(SaveLoadManager))]
+    [HarmonyPatch("PrivateLoadCommon")]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> TranspileSaveLoadManagerPrivateLoadCommon(IEnumerable<CodeInstruction> instructions)
+    {
+        return TranspileSequentialFlowBuilderMethod(instructions, FLOW_METHOD_PRIVATELOADCOMMON);
+    }
+
+    [HarmonyPatch(typeof(SaveLoadManager))]
+    [HarmonyPatch("PrivateSaveCommon")]
+    [HarmonyTranspiler]
+    public static IEnumerable<CodeInstruction> TranspileSaveLoadManagerPrivateSaveCommon(IEnumerable<CodeInstruction> instructions)
+    {
+        return TranspileSequentialFlowBuilderMethod(instructions, FLOW_METHOD_PRIVATESAVECOMMON);
+    }
+
+    private class SequentialFlowAdditions
+    {
+        readonly HashSet<Type> availableTypes;
+        readonly List<KeyValuePair<string, object>> insertAfter = new();
+        readonly internal MethodInfo method;
+
+        internal SequentialFlowAdditions(MethodInfo method)
+        {
+            availableTypes = new(method.GetParameters().Select(parameter => parameter.ParameterType).Where(type => !type.IsValueType)) { method.DeclaringType };
+            this.method = method;
+        }
+
+        internal void AddConstructor(string after, Type flowAction)
+        {
+            // Determine the correct constructor to use.
+            var constructor = flowAction.GetConstructors().OrderByDescending(constructor => constructor.GetParameters().Length).Where(constructor =>
+            {
+                HashSet<Type> seen = new();
+
+                foreach (var parameter in constructor.GetParameters())
+                {
+                    if (!availableTypes.Contains(parameter.ParameterType))
+                        return false;
+
+                    if (!seen.Add(parameter.GetType()))
+                        return false;
+                }
+
+                return true;
+            }).FirstOrDefault() ?? throw new InvalidOperationException($"Flow action type {flowAction.Name} does not have a public constructor that has parameters compatible with {method.DeclaringType.Name}.{method.Name}");
+
+            insertAfter.Add(new(after, constructor));
+        }
+
+        internal void AddAction(string after, FlowAction action)
+        {
+            insertAfter.Add(new(after, action));
+        }
+
+        static FlowAction Construct(ConstructorInfo constructor, object[] methodArguments)
+        {
+            // Figure out which type of object goes where in the arguments list.
+            Dictionary<Type, int> parameterIndices = new();
+
+            foreach (var parameter in constructor.GetParameters())
+            {
+                parameterIndices.Add(parameter.ParameterType, parameter.Position);
+            }
+
+            // Create and populate the arguments list
+            var arguments = new object[constructor.GetParameters().Length];
+
+            foreach (var obj in methodArguments)
+            {
+                if (parameterIndices.TryGetValue(obj.GetType(), out var index))
+                {
+                    arguments[index] = obj;
+                }
+            }
+
+            return (FlowAction)constructor.Invoke(arguments);
+        }
+
+        void AddActionsAfter(string name, List<FlowAction> actions, bool[] added, object[] methodArguments)
+        {
+            for (int i = 0; i < added.Length; i++)
+            {
+                // Action has already been added.
+                if (added[i])
+                    continue;
+
+                if (insertAfter[i].Key == name)
+                {
+                    added[i] = true;
+
+                    FlowAction action = null;
+
+                    if (insertAfter[i].Value is ConstructorInfo constructor)
+                    {
+                        action = Construct(constructor, methodArguments);
+                    }
+
+                    else if (insertAfter[i].Value is FlowAction flowAction)
+                    {
+                        action = flowAction;
+                    }
+
+                    actions.Add(action);
+
+                    // There could be actions set to run after the newly inserted action,
+                    // so this needs to be called again.
+                    AddActionsAfter(action.Name, actions, added, methodArguments);
+                }
+            }
+        }
+
+        internal void ApplyTo(SequentialFlow flow, object[] methodArguments)
+        {
+            // Uncomment this section to log a list of FlowActions in the flow by default,
+            // for use in the documentation of the methods in Loading.SaveLoad.
+            /*
+            StringBuilder sb = new("Flow items for ");
+            sb.Append(method.Name);
+            sb.Append(":\n");
+            foreach (var action in flow._flowActions)
+            {
+                sb.Append("<item><c>\"");
+                sb.Append(action.Name);
+                sb.Append("\"</c></item>\n");
+            }
+            Logger.CreateLogSource("SequentialFlow Logger").Log(LogLevel.Info, sb.ToString());
+            */
+
+            // New list of actions
+            List<FlowAction> actions = new();
+
+            // Has each action been added already?
+            // Used to prevent duplicates, and warn about unused actions.
+            var added = new bool[insertAfter.Count()];
+
+            // `null` is sued to signify the start of the action list.
+            AddActionsAfter(null, actions, added, methodArguments);
+
+            // Add actions from the existing flow, and any new ones in the right place.
+            foreach (var action in flow._flowActions)
+            {
+                actions.Add(action);
+                AddActionsAfter(action.Name, actions, added, methodArguments);
+            }
+
+            // Replace the flow's list with our new one.
+            flow._flowActions.Clear();
+            flow._flowActions.AddRange(actions);
+
+            // Warn about any actions that were not used.
+            for (int i = 0; i < added.Length; i++)
+            {
+                if (!added[i])
+                {
+                    if (insertAfter[i].Value is ConstructorInfo constructor)
+                    {
+                        var actionType = constructor.DeclaringType;
+                        var logger = Logger.CreateLogSource($"{actionType.Assembly.GetName().Name}/{actionType.Name}");
+                        logger.LogWarning($"Flow action {actionType.Name} was set to be inserted after \"{insertAfter[i].Key}\" in {method.Name}, however that action does not exist in that flow");
+                    }
+
+                    else if (insertAfter[i].Value is FlowAction action)
+                    {
+                        var logger = Logger.CreateLogSource("SequentialFlow");
+                        logger.LogWarning($"Flow action \"{action.Name}\" was set to be inserted after \"{insertAfter[i].Key}\" in {method.Name}, however that action does not exist in that flow");
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Provides an API for adding new FlowItems to the game's SequentialFlows in StartBootstrap/StartGame, PrivateLoadCommon, and PrivateSaveCommon.

Arguments passed to the creation of those flows are available when using the Generic methods, by taking the objects in the FlowAction's constructor.

APIs added:
- `SpaceWarp.API.Loading.SaveLoad.AddFlowActionToGameLoadAfter`
- `SpaceWarp.API.Loading.SaveLoad.AddFlowActionToCampaignLoadAfter`
- `SpaceWarp.API.Loading.SaveLoad.AddFlowActionToCampaignSaveAfter`

SpaceWarp currently inserts its own FlowActions into game loading by patching `GameManager.StartBootstrap`. This could be updated to use the system provided by this PR, which would eliminate the need for the complex ILContext-based system currently in use.