### PR TITLE
Add main menu warning if outdated or errored mods detected

### DIFF
--- a/SpaceWarp/SpaceWarpPlugin.cs
+++ b/SpaceWarp/SpaceWarpPlugin.cs
@@ -54,6 +54,7 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
     internal ConfigEntry<Color> ConfigAllColor;
     internal ConfigEntry<bool> ConfigCheckVersions;
     internal ConfigEntry<bool> ConfigShowMainMenuWarningForOutdatedMods;
+    internal ConfigEntry<bool> ConfigShowMainMenuWarningForErroredMods;
     internal ConfigEntry<Color> ConfigDebugColor;
     internal ConfigEntry<int> ConfigDebugMessageLimit;
     
@@ -122,6 +123,8 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
             "Whether or not Space Warp should check mod versions using their swinfo.json files");
         ConfigShowMainMenuWarningForOutdatedMods = Config.Bind("Version Checking", "Show Warning for Outdated Mods", true,
             "Whether or not Space Warp should display a warning in main menu if there are outdated mods");
+        ConfigShowMainMenuWarningForErroredMods = Config.Bind("Version Checking", "Show Warning for Errored Mods", true,
+            "Whether or not Space Warp should display a warning in main menu if there are errored mods");
     }
 
     private void SetupLuaState()

--- a/SpaceWarp/SpaceWarpPlugin.cs
+++ b/SpaceWarp/SpaceWarpPlugin.cs
@@ -53,9 +53,9 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
     public const string ModVer = MyPluginInfo.PLUGIN_VERSION;
     internal ConfigEntry<Color> ConfigAllColor;
     internal ConfigEntry<bool> ConfigCheckVersions;
+    internal ConfigEntry<bool> ConfigShowMainMenuWarningForOutdatedMods;
     internal ConfigEntry<Color> ConfigDebugColor;
     internal ConfigEntry<int> ConfigDebugMessageLimit;
-
     
     internal ConfigEntry<Color> ConfigErrorColor;
     private ConfigEntry<bool> _configFirstLaunch;
@@ -120,8 +120,9 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
             "Whether or not this is the first launch of space warp, used to show the version checking prompt to the user.");
         ConfigCheckVersions = Config.Bind("Version Checking", "Check Versions", false,
             "Whether or not Space Warp should check mod versions using their swinfo.json files");
+        ConfigShowMainMenuWarningForOutdatedMods = Config.Bind("Version Checking", "Show Warning for Outdated Mods", true,
+            "Whether or not Space Warp should display a warning in main menu if there are outdated mods");
     }
-
 
     private void SetupLuaState()
     {
@@ -148,7 +149,6 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
             }
         }
     }
-
 
     public override void OnInitialized()
     {
@@ -188,9 +188,8 @@ public sealed class SpaceWarpPlugin : BaseSpaceWarpPlugin
     public override void OnPostInitialized()
     {
         InitializeSettingsUI();
+        SpaceWarpManager.ModListController.AddMainMenuItem();
     }
-
-
 
     public void ClearVersions()
     {

--- a/SpaceWarp/UI/ModList/ModListController.cs
+++ b/SpaceWarp/UI/ModList/ModListController.cs
@@ -86,8 +86,18 @@ internal class ModListController : MonoBehaviour
     {
         _listEntryTemplate = AssetManager.GetAsset<VisualTreeAsset>($"{SpaceWarpPlugin.ModGuid}/modlist/modlistitem.uxml");
         _dependencyTemplate = AssetManager.GetAsset<VisualTreeAsset>($"{SpaceWarpPlugin.ModGuid}/modlist/modlistdependency.uxml");
+    }
 
-        MainMenu.RegisterLocalizedMenuButton("SpaceWarp/Mods", ToggleWindow);
+    internal void AddMainMenuItem()
+    {
+        string term;
+
+        if (SpaceWarpPlugin.Instance.ConfigShowMainMenuWarningForOutdatedMods.Value && SpaceWarpManager.ModsOutdated.ContainsValue(true))
+            term = "SpaceWarp/Mods/Outdated";
+        else
+            term = "SpaceWarp/Mods";
+
+        MainMenu.RegisterLocalizedMenuButton(term, ToggleWindow);
     }
 
     private void OnEnable()

--- a/SpaceWarp/UI/ModList/ModListController.cs
+++ b/SpaceWarp/UI/ModList/ModListController.cs
@@ -92,7 +92,9 @@ internal class ModListController : MonoBehaviour
     {
         string term;
 
-        if (SpaceWarpPlugin.Instance.ConfigShowMainMenuWarningForOutdatedMods.Value && SpaceWarpManager.ModsOutdated.ContainsValue(true))
+        if (SpaceWarpPlugin.Instance.ConfigShowMainMenuWarningForErroredMods.Value && SpaceWarpManager.ErroredPlugins?.Count > 0)
+            term = "SpaceWarp/Mods/Errored";
+        else if (SpaceWarpPlugin.Instance.ConfigShowMainMenuWarningForOutdatedMods.Value && SpaceWarpManager.ModsOutdated.ContainsValue(true))
             term = "SpaceWarp/Mods/Outdated";
         else
             term = "SpaceWarp/Mods";

--- a/SpaceWarpBuildTemplate/localizations/space_warp_localizations.csv
+++ b/SpaceWarpBuildTemplate/localizations/space_warp_localizations.csv
@@ -27,6 +27,7 @@ SpaceWarp/ModList/DisabledDependency,Text,,Dependency is disabled,Esta dependên
 SpaceWarp/ModList/UnspecifiedDependency,Text,,Dependency was not specified in SW info,Esta dependência não está presente no swinfo
 SpaceWarp/ModList/UnsupportedDependency,Text,,Dependency is of an unsupported version,Esta dependência é de uma versão nao suportada
 SpaceWarp/Mods,Text,,Mods,Mods
+SpaceWarp/Mods/Outdated,Text,,Mods <color=yellow>⚠</color>,Mods <color=yellow>⚠</color>
 SpaceWarp,Text,,Space Warp,Space Warp
 SpaceWarp/VersionChecking,Text,,Allow Space Warp to check versions for mods over the network?,Deixar SpaceWarp verificar a versão dos mods na internet?
 SpaceWarp/Yes,Text,,Yes,Sim

--- a/SpaceWarpBuildTemplate/localizations/space_warp_localizations.csv
+++ b/SpaceWarpBuildTemplate/localizations/space_warp_localizations.csv
@@ -28,6 +28,7 @@ SpaceWarp/ModList/UnspecifiedDependency,Text,,Dependency was not specified in SW
 SpaceWarp/ModList/UnsupportedDependency,Text,,Dependency is of an unsupported version,Esta dependência é de uma versão nao suportada
 SpaceWarp/Mods,Text,,Mods,Mods
 SpaceWarp/Mods/Outdated,Text,,Mods <color=yellow>⚠</color>,Mods <color=yellow>⚠</color>
+SpaceWarp/Mods/Errored,Text,,Mods <color=red>⚠</color>,Mods <color=red>⚠</color>
 SpaceWarp,Text,,Space Warp,Space Warp
 SpaceWarp/VersionChecking,Text,,Allow Space Warp to check versions for mods over the network?,Deixar SpaceWarp verificar a versão dos mods na internet?
 SpaceWarp/Yes,Text,,Yes,Sim


### PR DESCRIPTION
- Show yellow triangle next to "Mods" if SW detects at least one outdated mod
- Add settings config if warning should be displayed, defaults to true

Solves https://github.com/SpaceWarpDev/SpaceWarp/issues/214

![ShowMainMenuWarningForOutdatedMods](https://github.com/SpaceWarpDev/SpaceWarp/assets/72734856/406d975e-5113-4d80-b5a3-7de0f3a91dd6)
