### PR TITLE
Add KSC mod tray and ability for mods to and their button to the tray

### DIFF
--- a/SpaceWarp.UI/API/UI/Appbar/Appbar.cs
+++ b/SpaceWarp.UI/API/UI/Appbar/Appbar.cs
@@ -14,8 +14,9 @@ public static class Appbar
 {
     private static readonly List<(string text, Sprite icon, string ID, Action<bool> action)> ButtonsToBeLoaded = new();
 
-    private static readonly List<(string text, Sprite icon, string ID, Action<bool> action)> OABButtonsToBeLoaded =
-        new();
+    private static readonly List<(string text, Sprite icon, string ID, Action<bool> action)> OABButtonsToBeLoaded = new();
+
+    private static readonly List<(string text, Sprite icon, string ID, Action action)> KSCButtonsToBeLoaded = new();
 
     /// <summary>
     /// Register an appbar menu for the game
@@ -102,6 +103,30 @@ public static class Appbar
     }
 
     /// <summary>
+    /// Register a button on the KSC AppBar
+    /// </summary>
+    /// <param name="text">The text in the appbar menu</param>
+    /// <param name="id">A unique id for the appbar menu eg: "BTN-ExampleKSC"</param>
+    /// <param name="icon">A Sprite for the icon in the appbar</param>
+    /// <param name="func">The function to be called when this button is clicked</param>
+    public static void RegisterKSCAppButton(string text, string id, Sprite icon, Action func)
+    {
+        KSCButtonsToBeLoaded.Add((text, icon, id, func));
+    }
+
+    /// <summary>
+    /// Register a button on the KSC AppBar
+    /// </summary>
+    /// <param name="text">The text in the appbar menu</param>
+    /// <param name="id">A unique id for the appbar menu eg: "BTN-ExampleKSC"</param>
+    /// <param name="icon">A Texture2D for the icon in the appbar</param>
+    /// <param name="func">The function to be called when this button is clicked</param>
+    public static void RegisterKSCAppButton(string text, string id, Texture2D icon, Action func)
+    {
+        RegisterKSCAppButton(text, id, GetAppBarIconFromTexture(icon), func);
+    }
+
+    /// <summary>
     /// Convert a Texture2D to a Sprite
     /// </summary>
     /// <param name="texture">The Texture2D</param>
@@ -147,6 +172,14 @@ public static class Appbar
         foreach (var button in OABButtonsToBeLoaded)
         {
             AppbarBackend.AddOABButton(button.text, button.icon, button.ID, button.action);
+        }
+    }
+
+    internal static void LoadKSCButtons()
+    {
+        foreach (var button in KSCButtonsToBeLoaded)
+        {
+            AppbarBackend.AddKSCButton(button.text, button.icon, button.ID, button.action);
         }
     }
 }

--- a/SpaceWarp.UI/Backend/UI/Appbar/AppbarBackend.cs
+++ b/SpaceWarp.UI/Backend/UI/Appbar/AppbarBackend.cs
@@ -338,7 +338,7 @@ internal static class AppbarBackend
         // Change the text to APPS
         var title = kscAppTrayButton.GetChild("Header").GetChild("Content").GetChild("Title");
         {
-            // Suppress renaming of button to Launchpad
+            // Suppress renaming of the button to Launchpad
             var localizer = title.GetComponent<Localize>();
             if (localizer)
             {
@@ -352,11 +352,12 @@ internal static class AppbarBackend
         var kscAppTray = kscAppTrayButton.GetChild("LaunchLocationsFlyoutTarget");
         kscAppTray.name = "KSC-AppTray";
 
-        // Delete existing buttons in the tray
+        // Delete existing buttons and separators in the tray
         for (var i = 0; i < kscAppTray.transform.childCount; i++)
         {
             var child = kscAppTray.transform.GetChild(i);
 
+            // Destroy all objects inside the tray, but keep the arrow ("thingy") that points to the menu button
             if (!child.name.ToLowerInvariant().Contains("thingy"))
                 UnityObject.Destroy(child.gameObject);
         }
@@ -372,16 +373,6 @@ internal static class AppbarBackend
 
         // Grab the Launchpad_1 button, clone it and convert it to a mod launching button
 
-        //var list = GameObject.Find(
-        //    "GameManager/Default Game Instance(Clone)/UI Manager(Clone)/Scaled Popup Canvas/Container/ButtonBar/BTN-App-Tray/appbar-others-group");
-        //var resourceManger = list != null ? list.GetChild("BTN-Resource-Manager") : null;
-
-        //if (resourceManger == null)
-        //{
-        //    Logger.LogError("Couldn't find the appbar.");
-        //    return;
-        //}
-
         // Find the Launchpad_1 button.
         var kscLaunchLocationsFlyoutTarget = GameObject.Find(
             "GameManager/Default Game Instance(Clone)/UI Manager(Clone)/Main Canvas/KSCMenu(Clone)/LandingPanel/InteriorWindow/MenuButtons/Content/Menu/LaunchLocationFlyoutHeaderToggle/LaunchLocationsFlyoutTarget");
@@ -393,59 +384,28 @@ internal static class AppbarBackend
             return;
         }
 
-
-        // Clone the resource manager button.
-        //var appButton = UnityObject.Instantiate(resourceManger, KSCTray.transform);
-        //appButton.name = buttonId;
-        
+        // Clone the button, add it to the popup tray and rename it
         var modButton = UnityObject.Instantiate(launchPadButton, KSCTray.transform);
         modButton.name = buttonId;
 
 
-        // Change the text.
-        //var text = appButton.GetChild("Content").GetChild("TXT-title").GetComponent<TextMeshProUGUI>();
-        //text.text = buttonText;
-
+        // Change the text
         var modText = modButton.GetChild("Content").GetChild("Text (TMP)").GetComponent<TextMeshProUGUI>();
         modText.text = buttonText;
 
-        //var localizer = text.gameObject.GetComponent<Localize>();
-        //if (localizer)
-        //{
-        //    UnityObject.Destroy(localizer);
-        //}
-
+        // Suppress renaming of the button
         var localizer = modText.gameObject.GetComponent<Localize>();
         if (localizer)
         {
             UnityObject.Destroy(localizer);
         }
 
-        // Change the icon.
-        //var icon = appButton.GetChild("Content").GetChild("GRP-icon");
-        //var image = icon.GetChild("ICO-asset").GetComponent<Image>();
-        //image.sprite = buttonIcon;
-
+        // Change the icon
         var icon = modButton.GetChild("Icon");
         var image = icon.GetComponent<Image>();
         image.sprite = buttonIcon;
 
-        // Add our function call to the toggle.
-        //var utoggle = appButton.GetComponent<ToggleExtended>();
-        //utoggle.onValueChanged.AddListener(state =>
-        //{
-        //    Logger.LogInfo($"{buttonId}({state})");
-        //    function(state);
-        //});
-
-        // Set the initial state of the button.
-        //var toggle = appButton.GetComponent<UIValue_WriteBool_Toggle>();
-        //toggle.BindValue(new Property<bool>(false));
-
-        //// Bind the action to close the tray after pressing the button.
-        //void Action() => SetKSCTrayState(false);
-        //appButton.GetComponent<UIAction_Void_Toggle>().BindAction(new DelegateAction((Action)Action));
-
+        // Remove previous onclick listeners and add the function that mod will use
         var buttonExtended = modButton.GetComponent<ButtonExtended>();
         var previousListeners = modButton.GetComponent<UIAction_String_ButtonExtended>();
         if (previousListeners)
@@ -457,7 +417,7 @@ internal static class AppbarBackend
             Logger.LogInfo($"Mod button {buttonId} clicked.");
             function();
 
-            // Hide the tray
+            // Hide the popup tray after the button is clicked
             var toggle = KSCTray.GetComponentInParent<ToggleExtended>();
             toggle.isOn = false;
         });

--- a/SpaceWarp.UI/Backend/UI/Appbar/AppbarBackend.cs
+++ b/SpaceWarp.UI/Backend/UI/Appbar/AppbarBackend.cs
@@ -309,8 +309,6 @@ internal static class AppbarBackend
         }
     }
 
-    private static Property<bool> _kscState;
-
     private static GameObject CreateKSCTray()
     {
         Logger.LogInfo("Creating KSC app tray...");
@@ -323,15 +321,15 @@ internal static class AppbarBackend
 
         if (kscMenu == null || launchLocationsButton == null)
         {
-            Logger.LogError("Couldn't find KSC tray.");
+            Logger.LogError("Couldn't find Launch Pads menu item for cloning the KSC app tray.");
             return null;
         }
 
         // Clone it, add it to the menu and rename it
-        var kscAppTrayButton = UnityEngine.Object.Instantiate(launchLocationsButton, kscMenu.transform);
+        var kscAppTrayButton = UnityObject.Instantiate(launchLocationsButton, kscMenu.transform);
         kscAppTrayButton.name = "KSC-AppTrayButton";
 
-        // Set the button icon
+        // Set the button icon (use OAB app tray icon)
         var image = kscAppTrayButton.GetChild("Header").GetChild("Content").GetChild("Icon Panel").GetChild("icon").GetComponent<Image>();
         var tex = AssetManager.GetAsset<Texture2D>($"{SpaceWarpPlugin.ModGuid}/images/oabTrayButton.png");
         tex.filterMode = FilterMode.Point;
@@ -350,17 +348,17 @@ internal static class AppbarBackend
             text.text = "Apps";
         }
 
-        // Get the tray and rename it
+        // Get the popup tray and rename it
         var kscAppTray = kscAppTrayButton.GetChild("LaunchLocationsFlyoutTarget");
         kscAppTray.name = "KSC-AppTray";
 
-        // Delete existing buttons in the tray.
+        // Delete existing buttons in the tray
         for (var i = 0; i < kscAppTray.transform.childCount; i++)
         {
             var child = kscAppTray.transform.GetChild(i);
 
             if (!child.name.ToLowerInvariant().Contains("thingy"))
-                UnityEngine.Object.Destroy(child.gameObject);
+                UnityObject.Destroy(child.gameObject);
         }
 
         Logger.LogInfo("Created KSC app tray.");
@@ -371,6 +369,8 @@ internal static class AppbarBackend
     public static void AddKSCButton(string buttonText, Sprite buttonIcon, string buttonId, Action function)
     {
         Logger.LogInfo($"Adding KSC appbar button: {buttonId}.");
+
+        // Grab the Launchpad_1 button, clone it and convert it to a mod launching button
 
         //var list = GameObject.Find(
         //    "GameManager/Default Game Instance(Clone)/UI Manager(Clone)/Scaled Popup Canvas/Container/ButtonBar/BTN-App-Tray/appbar-others-group");
@@ -465,17 +465,6 @@ internal static class AppbarBackend
         Logger.LogInfo($"Added KSC appbar button: {buttonId}.");
     }
 
-    // TODO: delete?
-    private static void SetKSCTrayState(bool state)
-    {
-        if (_kscTray == null)
-        {
-            return;
-        }
-
-        _kscState.SetValue(state);
-    }
-
     #endregion
 }
 
@@ -494,7 +483,7 @@ internal class ToolbarBackendObject : KerbalBehavior
         yield return Type switch
         {
             AppbarEvent.Flight => new WaitForSeconds(1),
-            AppbarEvent.OAB => new WaitForSeconds(1),
+            AppbarEvent.OAB => new WaitForFixedUpdate(),
             AppbarEvent.KSC => new WaitForFixedUpdate(),
             _ => new WaitForSeconds(1)
         };

--- a/SpaceWarp.UI/Backend/UI/Appbar/AppbarBackend.cs
+++ b/SpaceWarp.UI/Backend/UI/Appbar/AppbarBackend.cs
@@ -388,7 +388,6 @@ internal static class AppbarBackend
         var modButton = UnityObject.Instantiate(launchPadButton, KSCTray.transform);
         modButton.name = buttonId;
 
-
         // Change the text
         var modText = modButton.GetChild("Content").GetChild("Text (TMP)").GetComponent<TextMeshProUGUI>();
         modText.text = buttonText;

--- a/SpaceWarp.UI/Modules/UI.cs
+++ b/SpaceWarp.UI/Modules/UI.cs
@@ -53,6 +53,7 @@ public class UI : SpaceWarpModule
     {
         AppbarBackend.AppBarInFlightSubscriber.AddListener(Appbar.LoadAllButtons);
         AppbarBackend.AppBarOABSubscriber.AddListener(Appbar.LoadOABButtons);
+        AppbarBackend.AppBarKSCSubscriber.AddListener(Appbar.LoadKSCButtons);
         Instance = this;
         ConfigErrorColor = new(ModuleConfiguration.Bind("Debug Console", "Color Error", Color.red,
             "The color for log messages that have the level: Error/Fatal (bolded)"));


### PR DESCRIPTION
This is similar to how app buttons are added in Flight and OAB scenes.
KSC tray is indended for mods that are used outside Flight and OAB.
Upcoming HUMANS and (probably) Life Support mods will use it.

Difference in relation to Flight/OAB trays is that KSC menu doesn't operate as a toggle, but rather like a general button; meaning there is no toggled state.

Example usage:
```
Appbar.RegisterKSCAppButton(
      "Text that will be displayed for the button",
      ToolbarKscButtonID,
      AssetManager.GetAsset<Texture2D>($"{SpaceWarpMetadata.ModID}/images/icon.png"),
      () =>
      {
            _isWindowOpen = !_isWindowOpen;
      }
);
```

![KscTray](https://github.com/SpaceWarpDev/SpaceWarp/assets/72734856/c204ac3f-a7e0-4da9-9c74-6f7eb50b6ab9)


