### PR TITLE
Add API registration for mods that want to use game's built-in saving and loading of data stored in the save game files

### DIFF
--- a/SpaceWarp.Core/API/SaveGameManager/ModSaves.cs
+++ b/SpaceWarp.Core/API/SaveGameManager/ModSaves.cs
@@ -1,0 +1,82 @@
+﻿using JetBrains.Annotations;
+using SpaceWarp.Backend.SaveGameManager;
+using System;
+using System.Collections.Generic;
+using SpaceWarp.API.Logging;
+
+namespace SpaceWarp.API.SaveGameManager;
+
+[PublicAPI]
+public static class ModSaves
+{
+    private static readonly ILogger _logger = new UnityLogSource("SpaceWarp.ModSaves");
+
+    internal static List<PluginSaveData> InternalPluginSaveData = new();
+
+    /// <summary>
+    /// Registers your mod data for saving and loading events.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="modGuid">Your mod GUID. Or, technically, any kind of string can be passed here, but what is mandatory is that it's unique compared to what other mods will use.</param>
+    /// <param name="saveData">Your object that will be saved to a save file during a save event and that will be updated when a load event pulls new data. Ensure that a new instance of this object is NOT created after registration.</param>
+    /// <param name="saveEventCallback">Function that will execute when a SAVE event is triggered. 'NULL' is also valid here if you don't need a callback.</param>
+    /// <param name="loadEventCallback">Function that will execute when a LOAD event is triggered. 'NULL' is also valid here if you don't need a callback.</param>
+    public static void RegisterSaveLoadGameData<T>(string modGuid, T saveData, Action<T> saveEventCallback, Action<T> loadEventCallback)
+    {
+        // Create adapter functions to convert Action<T> to CallbackFunctionDelegate
+        SaveGameCallbackFunctionDelegate saveCallbackAdapter = (object saveData) =>
+        {
+            if (saveEventCallback != null && saveData is T data)
+            {
+                saveEventCallback(data);
+            }
+        };
+
+        SaveGameCallbackFunctionDelegate loadCallbackAdapter = (object saveData) =>
+        {
+            if (loadEventCallback != null && saveData is T data)
+            {
+                loadEventCallback(data);
+            }
+        };
+
+        // Check if this GUID is already registered
+        if (InternalPluginSaveData.Find(p => p.ModGuid == modGuid) != null)
+        {
+            throw new ArgumentException($"Mod GUID '{modGuid}' is already registered. Skipping.", "modGuid");
+        }
+        else
+        {
+            InternalPluginSaveData.Add(new PluginSaveData { ModGuid = modGuid, SaveData = saveData, SaveEventCallback = saveCallbackAdapter, LoadEventCallback = loadCallbackAdapter });
+            _logger.LogInfo($"Registered '{modGuid}' for save/load events.");
+        }
+    }
+
+    /// <summary>
+    /// Unregister your previously registered mod data for saving and loading. Use this if you no longer need your data to be saved and loaded.
+    /// </summary>
+    /// <param name="modGuid">Your mod GUID you used when registering.</param>
+    public static void UnRegisterSaveLoadGameData(string modGuid)
+    {
+        var toRemove = InternalPluginSaveData.Find(p => p.ModGuid == modGuid);
+        if (toRemove != null)
+        {
+            InternalPluginSaveData.Remove(toRemove);
+            _logger.LogInfo($"Unregistered '{modGuid}' for save/load events.");
+        }
+    }
+
+    /// <summary>
+    /// Unregisters then again registers your mod data for saving and loading events
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="modGuid">Your mod GUID. Or, technically, any kind of string can be passed here, but what is mandatory is that it's unique compared to what other mods will use.</param>
+    /// <param name="saveData">Your object that will be saved to a save file during a save event and that will be updated when a load event pulls new data. Ensure that a new instance of this object is NOT created after registration.</param>
+    /// <param name="saveEventCallback">Function that will execute when a SAVE event is triggered. 'NULL' is also valid here if you don't need a callback.</param>
+    /// <param name="loadEventCallback">Function that will execute when a LOAD event is triggered. 'NULL' is also valid here if you don't need a callback.</param>
+    public static void ReregisterSaveLoadGameData<T>(string modGuid, T saveData, Action<T> saveEventCallback, Action<T> loadEventCallback)
+    {
+        UnRegisterSaveLoadGameData(modGuid);
+        RegisterSaveLoadGameData<T>(modGuid, saveData, saveEventCallback, loadEventCallback);
+    }
+}

--- a/SpaceWarp.Core/Backend/SaveGameManager/PluginSaveData.cs
+++ b/SpaceWarp.Core/Backend/SaveGameManager/PluginSaveData.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace SpaceWarp.Backend.SaveGameManager;
+
+internal delegate void SaveGameCallbackFunctionDelegate(object data);
+
+[Serializable]
+public class PluginSaveData
+{
+    public string ModGuid { get; set; }
+    public object SaveData { get; set; }
+
+    [NonSerialized]
+    internal SaveGameCallbackFunctionDelegate SaveEventCallback;
+    [NonSerialized]
+    internal SaveGameCallbackFunctionDelegate LoadEventCallback;
+}

--- a/SpaceWarp.Core/Backend/SaveGameManager/SpaceWarpSerializedSavedGame.cs
+++ b/SpaceWarp.Core/Backend/SaveGameManager/SpaceWarpSerializedSavedGame.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace SpaceWarp.Backend.SaveGameManager;
+
+/// <summary>
+/// Extension of game's save/load data class
+/// </summary>
+[Serializable]
+public class SpaceWarpSerializedSavedGame : KSP.Sim.SerializedSavedGame
+{
+    public List<PluginSaveData> SerializedPluginSaveData = new();
+}

--- a/SpaceWarp.Core/InternalUtilities/InternalExtensions.cs
+++ b/SpaceWarp.Core/InternalUtilities/InternalExtensions.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System;
 using UnityEngine;
 
 namespace SpaceWarp.InternalUtilities;
@@ -8,5 +10,26 @@ internal static class InternalExtensions
     {
         UnityObject.DontDestroyOnLoad(obj);
         obj.hideFlags |= HideFlags.HideAndDontSave;
+    }
+
+    internal static void CopyFieldAndPropertyDataFromSourceToTargetObject(object source, object target)
+    {
+        foreach (FieldInfo field in source.GetType().GetFields())
+        {
+            object value = field.GetValue(source);
+
+            try
+            {
+                field.SetValue(target, value);
+            }
+            catch (FieldAccessException)
+            { /* some fields are constants */ }
+        }
+
+        foreach (PropertyInfo property in source.GetType().GetProperties())
+        {
+            object value = property.GetValue(source);
+            property.SetValue(target, value);
+        }
     }
 }

--- a/SpaceWarp.Core/Patching/SaveGameManager/SaveGamePatches.cs
+++ b/SpaceWarp.Core/Patching/SaveGameManager/SaveGamePatches.cs
@@ -20,7 +20,7 @@ internal class SaveLoadPatches
     [HarmonyPatch(new Type[] { typeof(string), typeof(LoadGameData) })]
     private static void InjectPluginSaveGameData(string filename, LoadGameData data, SerializeGameDataFlowAction __instance)
     {
-        // Skip plugin data injection if there are not mods that have registered for save/load actions
+        // Skip plugin data injection if there are no mods that have registered for save/load actions
         if (ModSaves.InternalPluginSaveData.Count == 0)
             return;
 

--- a/SpaceWarp.Core/Patching/SaveGameManager/SaveGamePatches.cs
+++ b/SpaceWarp.Core/Patching/SaveGameManager/SaveGamePatches.cs
@@ -1,0 +1,89 @@
+﻿using HarmonyLib;
+using KSP.Game.Load;
+using KSP.IO;
+using SpaceWarp.API.Logging;
+using SpaceWarp.API.SaveGameManager;
+using SpaceWarp.Backend.SaveGameManager;
+using SpaceWarp.InternalUtilities;
+using System;
+
+namespace SpaceWarp.Patching.SaveGameManager;
+
+[HarmonyPatch]
+internal class SaveLoadPatches
+{
+    private static readonly ILogger _logger = new UnityLogSource("SpaceWarp.SaveLoadPatches");
+
+    /// SAVING ///
+
+    [HarmonyPatch(typeof(SerializeGameDataFlowAction), MethodType.Constructor), HarmonyPostfix]
+    [HarmonyPatch(new Type[] { typeof(string), typeof(LoadGameData) })]
+    private static void InjectPluginSaveGameData(string filename, LoadGameData data, SerializeGameDataFlowAction __instance)
+    {
+        // Skip plugin data injection if there are not mods that have registered for save/load actions
+        if (ModSaves.InternalPluginSaveData.Count == 0)
+            return;
+
+        // Take the game's LoadGameData, extend it with our own class and copy plugin save data to it
+        SpaceWarpSerializedSavedGame modSaveData = new();
+        InternalExtensions.CopyFieldAndPropertyDataFromSourceToTargetObject(data.SavedGame, modSaveData);
+        modSaveData.SerializedPluginSaveData = ModSaves.InternalPluginSaveData;
+        data.SavedGame = modSaveData;
+
+        // Initiate save callback for plugins that specified a callback function
+        foreach (var plugin in ModSaves.InternalPluginSaveData)
+        {
+            plugin.SaveEventCallback(plugin.SaveData);
+        }
+    }
+
+    /// LOADING ///
+
+    [HarmonyPatch(typeof(DeserializeContentsFlowAction), "DoAction"), HarmonyPrefix]
+    private static bool DeserializeLoadedPluginData(Action resolve, Action<string> reject, DeserializeContentsFlowAction __instance)
+    {
+        // Skip plugin deserialization if there are no mods that have registered for save/load actions
+        if (ModSaves.InternalPluginSaveData.Count == 0)
+            return true;
+
+        __instance._game.UI.SetLoadingBarText(__instance.Description);
+        try
+        {
+            // Deserialize save data to our own class that extends game's SerializedSavedGame
+            SpaceWarpSerializedSavedGame serializedSavedGame = new();
+            IOProvider.FromJsonFile<SpaceWarpSerializedSavedGame>(__instance._filename, out serializedSavedGame);
+            __instance._data.SavedGame = serializedSavedGame;
+            __instance._data.DataLength = IOProvider.GetFileSize(__instance._filename);
+
+            // Perform plugin load data if plugin data is found in the save file
+            if (serializedSavedGame.SerializedPluginSaveData.Count > 0)
+            {
+                // Iterate through each plugin
+                foreach (var loadedData in serializedSavedGame.SerializedPluginSaveData)
+                {
+                    // Match registered plugin GUID with the GUID found in the save file
+                    var existingData = ModSaves.InternalPluginSaveData.Find(p => p.ModGuid == loadedData.ModGuid);
+                    if (existingData == null)
+                    {
+                        _logger.LogWarning($"Saved data for plugin '{loadedData.ModGuid}' found during a load event, however that plugin isn't registered for save/load events. Skipping load for this plugin.");
+                        continue;
+                    }
+
+                    // Perform a callback if plugin specified a callback function. This is done before plugin data is actually updated.
+                    existingData.LoadEventCallback(loadedData.SaveData);
+
+                    // Copy loaded data to the SaveData object plugin registered
+                    InternalExtensions.CopyFieldAndPropertyDataFromSourceToTargetObject(loadedData.SaveData, existingData.SaveData);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            UnityEngine.Debug.LogException(ex);
+            reject(ex.Message);
+        }
+        resolve();
+
+        return false;
+    }
+}


### PR DESCRIPTION
This adds 3 API methods for mods to:
- Register their mods for save/load events
- Unregister
- Reregister

Usage is:

```
SpaceWarp.API.SaveGameManager.ModSaves.RegisterSaveLoadGameData(
            "my.mod.guid",
            MySaveDataObject,
            (savedData) =>
            {
                // This function will be called when a SAVE event is triggered.
                // If you don't need to do anything on save events, pass null instead of this function.
            },
            (loadedData) =>
            {
                // This function will be called when a LOAD event is triggered and BEFORE data is loaded to your saveData object.
                // You don't need to manually update your data. It will be updated after this function.
                // If you don't need to do anything on load events, pass null instead of this function.
            }
        );
```

MySaveDataObject can be any kind of object.

I'll keep this as a draft for a while to get comments and so I could test it in real scenarios more thoroughly.